### PR TITLE
Update pydantic version and add Travis CI.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @RohitK89 @mariusvniekerk

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# After changing this file, check it on:
+#   http://lint.travis-ci.org/
+language: python
+group: travis_latest
+dist: xenial
+
+matrix:
+  include:
+    - python: 3.6
+    - python: 3.7
+    - python: 3.8
+
+before_install:
+  - pip install -r requirements.txt
+  - pip install pre-commit
+  - pip install pytest
+
+script:
+  - pre-commit run --all-files
+  - python -m pytest .

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - hvac
     - psycopg2
     - pyathena
-    - pydantic =0.32.2
+    - pydantic
     - pyyaml
     - requests
     - six

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pre_commit
   - psycopg2
   - pyathena
-  - pydantic =0.32.2
+  - pydantic
   - pytest
   - pyyaml
   - requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+boto3
+click
+hvac
+psycopg2
+pyathena
+pydantic
+pyyaml
+requests
+six
+sqlalchemy
+toolz
+tqdm
+urllib3


### PR DESCRIPTION
Setting up Travis for testing builds. Will be setting up builds and releases in
a separate commit.

This change also unpins pydantic since the issue that existed in 1.0 has since
been resolved (https://github.com/samuelcolvin/pydantic/pull/962).