### PR TITLE
Allow for adding tags directly to data sources

### DIFF
--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -49,6 +49,11 @@ credentials:
   source: ENV
   key: USER_PASSWORD
   username: service_user
+# Tags to apply directly to data sources created by this config file. 
+# Key follows the pattern <prefix>_<schema>, where prefix matches with PREFIX_MAP in data_source.py
+tags:
+  pg_baz: ["tag1", "tag2"]
+  pg_foo: ["tag3", "tag4"]
 ```
 
 **Note:** For AWS Redshift, use the same format as above, replacing the `handler_type` value with `Redshift`.
@@ -80,9 +85,13 @@ credentials:
   # Read from an instance of Hashicorp Vault
   source: VAULT
   key: path/to/vault/secret
+# Tags to apply directly to data sources created by this config file. 
+# Key follows the pattern <prefix>_<schema>, where prefix matches with PREFIX_MAP in data_source.py
+tags:
+  ath_foo: ["tag1", "tag2"]
 ```
 
-# Tags
+# Data Source Column Tags
 
 Information about what tags to create and how to attach them to columns in data sources should be specified through YAML files created under a `tags` directory within `config_root`.
 

--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -49,7 +49,7 @@ credentials:
   source: ENV
   key: USER_PASSWORD
   username: service_user
-# Tags to apply directly to data sources created by this config file. 
+# Tags to apply directly to data sources created by this config file.
 # Key follows the pattern <prefix>_<schema>, where prefix matches with PREFIX_MAP in data_source.py
 tags:
   pg_baz: ["tag1", "tag2"]
@@ -85,7 +85,7 @@ credentials:
   # Read from an instance of Hashicorp Vault
   source: VAULT
   key: path/to/vault/secret
-# Tags to apply directly to data sources created by this config file. 
+# Tags to apply directly to data sources created by this config file.
 # Key follows the pattern <prefix>_<schema>, where prefix matches with PREFIX_MAP in data_source.py
 tags:
   ath_foo: ["tag1", "tag2"]

--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -52,7 +52,7 @@ credentials:
 # Tags to apply directly to data sources created by this config file.
 # Key follows the pattern <prefix>_<schema>, where prefix matches with PREFIX_MAP in data_source.py
 tags:
-  pg_baz: ["tag1", "tag2"]
+  pg_baz: ["tag1", "tag2.subtag2"]
   pg_foo: ["tag3", "tag4"]
 ```
 
@@ -88,7 +88,7 @@ credentials:
 # Tags to apply directly to data sources created by this config file.
 # Key follows the pattern <prefix>_<schema>, where prefix matches with PREFIX_MAP in data_source.py
 tags:
-  ath_foo: ["tag1", "tag2"]
+  ath_foo: ["tag1", "tag2.subtag2"]
 ```
 
 # Data Source Column Tags

--- a/doc/managing_data_sources.md
+++ b/doc/managing_data_sources.md
@@ -28,8 +28,7 @@ If data sources are created using fh-immuta-utils, they'll be tagged during crea
 Note that tagging is not done for data sources that are bulk-created, as the endpoint used in Immuta's API for that purpose
 doesn't support applying tags during creation.
 
-
-To ensure that tags are kept up-to-date in existing data sources, you can run the following script:
+To ensure that data source and column tags are kept up-to-date in existing data sources, you can run the following script:
 
 ``` bash
 $ fh-immuta-utils data-sources tag-existing --config-file foo.yml

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -519,5 +519,6 @@ class ImmutaClient(LoggingMixin):
         res.raise_for_status()
         return True
 
+
 def get_client(base_url: str, auth_config: Dict[str, Any], **kwargs) -> ImmutaClient:
     return ImmutaClient(base_url=f"https://{base_url}", **auth_config)

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -508,6 +508,16 @@ class ImmutaClient(LoggingMixin):
         assert isinstance(id, int)
         return id
 
+    def tag_data_source(self, id: int, tag_data: List[Dict[str, Any]]) -> bool:
+        """
+        Adds tags to the data source directly, not to columns within the data source.
+        :param id: data source id
+        :param tag_data: list of tag dicts to apply to the data source
+        :return: True
+        """
+        res = self._session.post(f"tag/datasource/{id}", json=tag_data)
+        res.raise_for_status()
+        return True
 
 def get_client(base_url: str, auth_config: Dict[str, Any], **kwargs) -> ImmutaClient:
     return ImmutaClient(base_url=f"https://{base_url}", **auth_config)

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -61,18 +61,25 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
         progress_iterator.set_description(
             desc=f"Tagging ID: {data_source['id']}, Name: {data_source['name']} :"
         )
+        data_source_tags = tagger.get_tags_for_data_source(name=data_source['name'])
+        if data_source_tags:
+            logging.debug(f"Adding data source tags to {data_source['name']}.")
+            if not dry_run:
+                client.tag_data_source(
+                    id=data_source["id"], tag_data=data_source_tags
+                )
         dictionary = client.get_data_source_dictionary(id=data_source["id"])
         enriched_columns = tagger.enrich_columns_with_tagging(dictionary.metadata)
         if enriched_columns == dictionary.metadata:
             logging.debug(
-                f"No change for data source: {data_source['name']}. Skipping."
+                f"No change to column tags for data source: {data_source['name']}. Skipping."
             )
             continue
         logging.debug(
             f"Enriched columns for {data_source['name']}:"
             f" {dictionary.dict()['metadata']}"
         )
-        logging.info(f"Change detected. Updating data source {data_source['name']}.")
+        logging.info(f"Change detected to column tags. Updating data source {data_source['name']}'s data dictionary.")
         dictionary.metadata = enriched_columns
         if not dry_run:
             client.update_data_source_dictionary(

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -61,13 +61,11 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
         progress_iterator.set_description(
             desc=f"Tagging ID: {data_source['id']}, Name: {data_source['name']} :"
         )
-        data_source_tags = tagger.get_tags_for_data_source(name=data_source['name'])
+        data_source_tags = tagger.get_tags_for_data_source(name=data_source["name"])
         if data_source_tags:
             logging.debug(f"Adding data source tags to {data_source['name']}.")
             if not dry_run:
-                client.tag_data_source(
-                    id=data_source["id"], tag_data=data_source_tags
-                )
+                client.tag_data_source(id=data_source["id"], tag_data=data_source_tags)
         dictionary = client.get_data_source_dictionary(id=data_source["id"])
         enriched_columns = tagger.enrich_columns_with_tagging(dictionary.metadata)
         if enriched_columns == dictionary.metadata:
@@ -79,7 +77,9 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
             f"Enriched columns for {data_source['name']}:"
             f" {dictionary.dict()['metadata']}"
         )
-        logging.info(f"Change detected to column tags. Updating data source {data_source['name']}'s data dictionary.")
+        logging.info(
+            f"Change detected to column tags. Updating data source {data_source['name']}'s data dictionary."
+        )
         dictionary.metadata = enriched_columns
         if not dry_run:
             client.update_data_source_dictionary(

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -41,14 +41,22 @@ class Tagger(object):
             logging.debug("Reading tag file: %s", tag_file)
             with open(tag_file) as handle:
                 contents = yaml.safe_load(handle)
-                self.tag_map_datadict = {**self.tag_map_datadict, **contents.get("TAG_MAP", {})}
+                self.tag_map_datadict = {
+                    **self.tag_map_datadict,
+                    **contents.get("TAG_MAP", {}),
+                }
                 self.tag_groups = {**self.tag_groups, **contents.get("TAG_GROUPS", {})}
 
-        for datasource_file in glob.glob(os.path.join(config_root, "enrolled_datasets", "*.yml")):
+        for datasource_file in glob.glob(
+            os.path.join(config_root, "enrolled_datasets", "*.yml")
+        ):
             logging.debug("Reading enrolled data source file: %s", datasource_file)
             with open(datasource_file) as handle:
                 contents = yaml.safe_load(handle)
-                self.tag_map_datasource = {**self.tag_map_datasource, **contents.get("tags", {})}
+                self.tag_map_datasource = {
+                    **self.tag_map_datasource,
+                    **contents.get("tags", {}),
+                }
 
     def get_tags_for_column(self, column_name: str) -> List[str]:
         return self.tag_map_datadict.get(column_name, [])

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -123,7 +123,7 @@ class Tagger(object):
     def make_tags(self, client: "ImmutaClient") -> None:
         LOGGER.debug("Creating tags")
         for (root_tag, children) in self.tags_to_make():
-            LOGGER.info(f"Creating root tag: {root_tag}, children: {children}")
+            LOGGER.debug(f"Creating root tag: {root_tag}, children: {children}")
             client.create_tag(
                 tag_data=self.create_message_body_for_tag_creation(
                     root_tag=root_tag, children=children

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -26,10 +26,14 @@ class Tagger(object):
 
     def __init__(self, config_root: str) -> None:
         # column_name: [tag1, tag2, ...]
-        self.tag_map: Dict[str, List[str]] = {}
+        self.tag_map_datadict: Dict[str, List[str]] = {}
+
+        # prefix_schema: [tag1, tag2, ...]
+        self.tag_map_datasource: Dict[str, List[str]] = {}
 
         # tag_name: [iam_group_1, iam_group_2, ...]
         self.tag_groups: Dict[str, List[str]] = {}
+
         self.read_configs(config_root=config_root)
 
     def read_configs(self, config_root: str) -> None:
@@ -37,11 +41,31 @@ class Tagger(object):
             logging.debug("Reading tag file: %s", tag_file)
             with open(tag_file) as handle:
                 contents = yaml.safe_load(handle)
-                self.tag_map = {**self.tag_map, **contents.get("TAG_MAP", {})}
+                self.tag_map_datadict = {**self.tag_map_datadict, **contents.get("TAG_MAP", {})}
                 self.tag_groups = {**self.tag_groups, **contents.get("TAG_GROUPS", {})}
 
+        for datasource_file in glob.glob(os.path.join(config_root, "enrolled_datasets", "*.yml")):
+            logging.debug("Reading enrolled data source file: %s", datasource_file)
+            with open(datasource_file) as handle:
+                contents = yaml.safe_load(handle)
+                self.tag_map_datasource = {**self.tag_map_datasource, **contents.get("tags", {})}
+
     def get_tags_for_column(self, column_name: str) -> List[str]:
-        return self.tag_map.get(column_name, [])
+        return self.tag_map_datadict.get(column_name, [])
+
+    def get_tags_for_data_source(self, name: str) -> List[Dict[str, Any]]:
+        """
+        Finds tags whose key matches the prefix of the data source name.
+        e.g. if key is "ath_foo", all data sources with prefix "ath_foo" will get that key's tags
+        :param name: data source name
+        :return: list of tag dicts
+        """
+        tags = []
+        for k, v in self.tag_map_datasource.items():
+            if name.startswith(k):
+                for tag in v:
+                    tags.append({"name": tag, "source": "curated"})
+        return tags
 
     def is_root_tag(self, tag_to_check: str) -> bool:
         for tag in self.tag_groups:
@@ -58,8 +82,10 @@ class Tagger(object):
         Yields a dict of either str or List[str] where the key is a parent tag
         and the value is a list of child tags if any, or the parent tag itself if no children.
         """
+
         all_tags: Dict[str, List[str]] = defaultdict(list)
-        for tag_list in self.tag_map.values():
+        datasource_datadict_tags = {**self.tag_map_datadict, **self.tag_map_datasource}
+        for tag_list in datasource_datadict_tags.values():
             for tag in tag_list:
                 parent = tag.split(".")[0]
                 if tag not in all_tags[parent]:
@@ -89,7 +115,7 @@ class Tagger(object):
     def make_tags(self, client: "ImmutaClient") -> None:
         LOGGER.debug("Creating tags")
         for (root_tag, children) in self.tags_to_make():
-            LOGGER.debug(f"Creating root tag: {root_tag}, children: {children}")
+            LOGGER.info(f"Creating root tag: {root_tag}, children: {children}")
             client.create_tag(
                 tag_data=self.create_message_body_for_tag_creation(
                     root_tag=root_tag, children=children

--- a/fh_immuta_utils/tests/test_tagging.py
+++ b/fh_immuta_utils/tests/test_tagging.py
@@ -12,7 +12,7 @@ TAG_GROUPS = {
     "foobar": ["group_foobar"],
     "bar.baz": ["group_baz"],
 }
-DATA_SOURCE_TAGS = {"ath_succeed": ["eeny", "meeny"], "rs_fail": ["miny"]}
+DATA_SOURCE_TAGS = {"ath_succeed": ["eeny", "meeny.miny"], "rs_fail": ["moe"]}
 
 
 @pytest.fixture
@@ -43,15 +43,15 @@ def test_tags_to_make(tagger):
         ("foobar", []),
         ("bar", ["bar.baz"]),
         ("eeny", []),
-        ("meeny", []),
-        ("miny", []),
+        ("meeny", ["meeny.miny"]),
+        ("moe", []),
     ]
 
 
 def test_get_tags_for_data_source(tagger):
     expected = [
         {"name": "eeny", "source": "curated"},
-        {"name": "meeny", "source": "curated"},
+        {"name": "meeny.miny", "source": "curated"},
     ]
     assert tagger.get_tags_for_data_source(name="ath_succeed_foo") == expected
     assert tagger.get_tags_for_data_source(name="ath_fail_bar") == []

--- a/fh_immuta_utils/tests/test_tagging.py
+++ b/fh_immuta_utils/tests/test_tagging.py
@@ -12,10 +12,8 @@ TAG_GROUPS = {
     "foobar": ["group_foobar"],
     "bar.baz": ["group_baz"],
 }
-DATA_SOURCE_TAGS = {
-    "ath_succeed": ["eeny", "meeny"],
-    "rs_fail": ["miny"]
-}
+DATA_SOURCE_TAGS = {"ath_succeed": ["eeny", "meeny"], "rs_fail": ["miny"]}
+
 
 @pytest.fixture
 def tagger():
@@ -46,7 +44,7 @@ def test_tags_to_make(tagger):
         ("bar", ["bar.baz"]),
         ("eeny", []),
         ("meeny", []),
-        ("miny", [])
+        ("miny", []),
     ]
 
 

--- a/fh_immuta_utils/tests/test_tagging.py
+++ b/fh_immuta_utils/tests/test_tagging.py
@@ -12,14 +12,18 @@ TAG_GROUPS = {
     "foobar": ["group_foobar"],
     "bar.baz": ["group_baz"],
 }
-
+DATA_SOURCE_TAGS = {
+    "ath_succeed": ["eeny", "meeny"],
+    "rs_fail": ["miny"]
+}
 
 @pytest.fixture
 def tagger():
     with mock.patch("fh_immuta_utils.tagging.Tagger.read_configs", return_value=None):
         obj = tg.Tagger(config_root="")
-        obj.tag_map = TAG_MAP
+        obj.tag_map_datadict = TAG_MAP
         obj.tag_groups = TAG_GROUPS
+        obj.tag_map_datasource = DATA_SOURCE_TAGS
     return obj
 
 
@@ -40,7 +44,19 @@ def test_tags_to_make(tagger):
         ("foo", []),
         ("foobar", []),
         ("bar", ["bar.baz"]),
+        ("eeny", []),
+        ("meeny", []),
+        ("miny", [])
     ]
+
+
+def test_get_tags_for_data_source(tagger):
+    expected = [
+        {"name": "eeny", "source": "curated"},
+        {"name": "meeny", "source": "curated"},
+    ]
+    assert tagger.get_tags_for_data_source(name="ath_succeed_foo") == expected
+    assert tagger.get_tags_for_data_source(name="ath_fail_bar") == []
 
 
 TagMsgBody = namedtuple("TagMsgBody", ["root_tag", "children", "expected"])


### PR DESCRIPTION
Adds functionality to tag data sources directly. This will be needed once we start using `fh-immuta-utils` to build subscription policies that depend on these tags. Docs also updated.

Tested on Immuta app versions 2.6 and 2020.2.3