### PR TITLE
Make PolicyGroup iam parameter optional

### DIFF
--- a/fh_immuta_utils/policy.py
+++ b/fh_immuta_utils/policy.py
@@ -23,7 +23,7 @@ class ActionType(Enum):
 
 class PolicyGroup(BaseModel):
     name: str
-    iam: str
+    iam: Optional[str] = ""
 
 
 class ColumnTag(BaseModel):


### PR DESCRIPTION
Recent testing with Immuta app v2020.3.2 revealed that the `iam` parameter for policy conditions is no longer returned by the Immuta API. This is causing an error to be thrown because `iam` is a required field currently in the `PolicyGroup` class.

Change here makes the `iam` parameter optional for `PolicyGroup`.