### PR TITLE
Add ability to control schema evolution settings for a remote database

### DIFF
--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -23,6 +23,14 @@ The supported auth schemes can be found in `config.py`.
 All specs for enrolled data sources should be placed inside a directory named `enrolled_datasets` within the `config_root`.
 fh-immuta-utils globs for all YAML files within that directory and then processes each.
 
+### Query Engine Table Name and Immuta Data Source Name Character Limits
+
+A character limit is enforced on all enrolled data sources as follows:
+
+* **Query engine table name**: 255 character limit. If exceeded, name is truncated at the end to meet the limit.
+* **Immuta data source name**: 255 character limit. If exceeded, name is truncated to (limit - 8) characters, and the
+  last 8 characters are replaced with a hash generated from the name.
+
 ### Schema Evolution
 
 Schema evolution (aka schema monitoring) can be enabled or disabled across all query-backed data sources for a remote

--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -59,7 +59,7 @@ hostname: my-database.foo.com
 port: 5439
 database: db-name
 # Prefix to prepend to name of data source created in Immuta
-prefix:
+user_prefix:
 handler_type: PostgreSQL
 # List of schemas to enroll where for each schema,
 # we only want to enroll tables with a specific name/prefix
@@ -100,7 +100,7 @@ An example of a state file for an AWS Athena database is as follows:
 region: us-east-1
 hostname: us-east-1
 database: my-database
-# Prefix to add to name of data source created in Immuta
+# Prefix to prepend to name of data source created in Immuta
 user_prefix:
 handler_type: Amazon Athena
 queryResultLocationBucket: bucket-where-results-should-be-stored

--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -44,9 +44,9 @@ Defaults for the naming templates are shown in the example configurations below.
 the schema evolution section when creating or editing a data source can be used in the template strings. The available
 template strings are:
 
-1. **immuta_name_format**: Template for Immuta data source names
-2. **sql_table_name_format**: Template for Query Engine SQL table names
-3. **sql_schema_name_format**: Template for the Query Engine schema to use when enrolling tables
+1. **datasource_name_format**: Template for Immuta data source names
+2. **query_engine_table_name_format**: Template for Query Engine SQL table names
+3. **query_engine_schema_name_format**: Template for the Query Engine schema to use when enrolling tables
 
 ### Example Query-Backed Data Source Configurations
 
@@ -73,9 +73,9 @@ schemas_to_bulk_enroll:
 # Schema evolution enablement and naming templates
 schema_evolution:
   disable_schema_evolution: true
-  immuta_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
-  sql_table_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
-  sql_schema_name_format: "<schema>"
+  datasource_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  query_engine_table_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  query_engine_schema_name_format: "<schema>"
 credentials:
   # Read from environment variable
   source: ENV
@@ -116,9 +116,9 @@ schemas_to_bulk_enroll:
 # Schema evolution enablement and naming templates
 schema_evolution:
   disable_schema_evolution: true
-  immuta_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
-  sql_table_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
-  sql_schema_name_format: "<schema>"
+  datasource_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  query_engine_table_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  query_engine_schema_name_format: "<schema>"
 credentials:
   # Read from an instance of Hashicorp Vault
   source: VAULT

--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -1,7 +1,6 @@
-Configuration
-=============
+# Configuration
 
-# Base Config File
+## Base Config File
 The scripts inside fh-immuta-utils expect a config file specifying how to connect to your Immuta instance as well as the details around whatever state you're trying to manage.
 
 An example config file is as follows:
@@ -19,12 +18,39 @@ The `config_root` key specifies the directory containing all the state configura
 
 The supported auth schemes can be found in `config.py`.
 
-# Data Source State
+## Data Source State
 
 All specs for enrolled data sources should be placed inside a directory named `enrolled_datasets` within the `config_root`.
 fh-immuta-utils globs for all YAML files within that directory and then processes each.
 
-## PostgreSQL
+### Schema Evolution
+
+Schema evolution (aka schema monitoring) can be enabled or disabled across all query-backed data sources for a remote
+database/server. For more information on schema evolution, please refer to the internal Immuta documentation page titled
+"Schema Monitoring".
+
+Note the following:
+
+* Enabling or disabling schema evolution requires a schema value is present in the `schemas_to_bulk_enroll` key in the
+  configuration. **When enabling schema evolution for the first time for a remote database**, a bulk enroll of a
+  non-enrolled schema must be run to correctly create the schema evolution record in Immuta
+* Data sources enrolled with schema evolution automatically have table evolution enabled. See the internal Immuta
+  documentation page titled "Schema Monitoring" for more information on table evolution.
+* Schemas and tables are enrolled with the currently authenticated user running `fh-immuta-utils` as the owner
+* Enabling or disabling schema evolution for specific schemas within a remote database/server is not currently
+  supported
+
+Defaults for the naming templates are shown in the example configurations below. Any of the macros shown in the UI in
+the schema evolution section when creating or editing a data source can be used in the template strings. The available
+template strings are:
+
+1. **immuta_name_format**: Template for Immuta data source names
+2. **sql_table_name_format**: Template for Query Engine SQL table names
+3. **sql_schema_name_format**: Template for the Query Engine schema to use when enrolling tables
+
+### Example Query-Backed Data Source Configurations
+
+#### PostgreSQL
 
 An example of a state file for a PostgreSQL database is as follows:
 
@@ -44,15 +70,11 @@ schemas_to_enroll:
 # List of schemas where we want to enroll all tables in each schema
 schemas_to_bulk_enroll:
   - schema_prefix: "baz"
-# Schema evolution enablement and naming templates. Defaults are shown. Any of the macros shown in the UI when creating
-# or editing a data source to enable schema monitoring can be used in the template strings.
-# immuta_name_format = Template for Immuta data source names
-# sql_table_name_format = Template for Query Engine SQL table names
-# sql_schema_name_format = Template for the Query Engine schema to use when enrolling tables
+# Schema evolution enablement and naming templates
 schema_evolution:
   disable_schema_evolution: true
   immuta_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
-  sql_table_name_format "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  sql_table_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
   sql_schema_name_format: "<schema>"
 credentials:
   # Read from environment variable
@@ -68,7 +90,7 @@ tags:
 
 **Note:** For AWS Redshift, use the same format as above, replacing the `handler_type` value with `Redshift`.
 
-## AWS Athena
+#### AWS Athena
 
 An example of a state file for an AWS Athena database is as follows:
 
@@ -91,15 +113,11 @@ schemas_to_enroll:
     table_prefix: bar
 # List of schemas where we want to enroll all tables in each schema
 schemas_to_bulk_enroll:
-# Schema evolution enablement and naming templates. Defaults are shown. Any of the macros shown in the UI when creating
-# or editing a data source to enable schema monitoring can be used in the template strings.
-# immuta_name_format = Template for Immuta data source names
-# sql_table_name_format = Template for Query Engine SQL table names
-# sql_schema_name_format = Template for the Query Engine schema to use when enrolling tables
+# Schema evolution enablement and naming templates
 schema_evolution:
   disable_schema_evolution: true
   immuta_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
-  sql_table_name_format "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  sql_table_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
   sql_schema_name_format: "<schema>"
 credentials:
   # Read from an instance of Hashicorp Vault
@@ -111,7 +129,7 @@ tags:
   ath_foo: ["tag1", "tag2.subtag2"]
 ```
 
-# Data Source Column Tags
+## Data Source Column Tags
 
 Information about what tags to create and how to attach them to columns in data sources should be specified through YAML files created under a `tags` directory within `config_root`.
 

--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -32,8 +32,8 @@ An example of a state file for a PostgreSQL database is as follows:
 hostname: my-database.foo.com
 port: 5439
 database: db-name
-# Prefix to add to name of data source created in Immuta
-user_prefix:
+# Prefix to prepend to name of data source created in Immuta
+prefix:
 handler_type: PostgreSQL
 # List of schemas to enroll where for each schema,
 # we only want to enroll tables with a specific name/prefix
@@ -44,6 +44,16 @@ schemas_to_enroll:
 # List of schemas where we want to enroll all tables in each schema
 schemas_to_bulk_enroll:
   - schema_prefix: "baz"
+# Schema evolution enablement and naming templates. Defaults are shown. Any of the macros shown in the UI when creating
+# or editing a data source to enable schema monitoring can be used in the template strings.
+# immuta_name_format = Template for Immuta data source names
+# sql_table_name_format = Template for Query Engine SQL table names
+# sql_schema_name_format = Template for the Query Engine schema to use when enrolling tables
+schema_evolution:
+  disable_schema_evolution: true
+  immuta_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  sql_table_name_format "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  sql_schema_name_format: "<schema>"
 credentials:
   # Read from environment variable
   source: ENV
@@ -81,6 +91,16 @@ schemas_to_enroll:
     table_prefix: bar
 # List of schemas where we want to enroll all tables in each schema
 schemas_to_bulk_enroll:
+# Schema evolution enablement and naming templates. Defaults are shown. Any of the macros shown in the UI when creating
+# or editing a data source to enable schema monitoring can be used in the template strings.
+# immuta_name_format = Template for Immuta data source names
+# sql_table_name_format = Template for Query Engine SQL table names
+# sql_schema_name_format = Template for the Query Engine schema to use when enrolling tables
+schema_evolution:
+  disable_schema_evolution: true
+  immuta_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  sql_table_name_format "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  sql_schema_name_format: "<schema>"
 credentials:
   # Read from an instance of Hashicorp Vault
   source: VAULT

--- a/doc/managing_data_sources.md
+++ b/doc/managing_data_sources.md
@@ -7,7 +7,7 @@ Assuming that you've created state files for data sources as specified in the [C
 you can invoke a script within the repo to manage all datasets for you in your Immuta instance.
 
 ``` bash
-$ fh-immuta-utils data-sources manage --config-file foo.yml
+$ fh-immuta-utils data-source manage --config-file foo.yml
 ```
 
 For a list of supported args, please run with `--help`.
@@ -15,7 +15,7 @@ For a list of supported args, please run with `--help`.
 # Deletion
 
 ``` bash
-$ fh-immuta-utils data-sources bulk-delete --config-file foo.yml --search-text foo
+$ fh-immuta-utils data-source bulk-delete --config-file foo.yml --search-text foo
 ```
 
 Note that unless triggered with `--hard-delete`, the script will only disable a data source in Immuta and not actually delete it.

--- a/doc/managing_policies.md
+++ b/doc/managing_policies.md
@@ -1,5 +1,6 @@
-Policies
-========
+# Policies
+
+## Data Policies
 
 fh-immuta-utils supports creating global policies to limit access to data sources based on tags.
 The intended use-case is where access to sensitive data is granted on the basis of membership in IAM groups,
@@ -7,7 +8,7 @@ where sensitive columns in data sources are tagged as such.
 
 The repo provides a script that can create, update, and remove policies based on provided policy spec files.
 
-As an example, imagine that the following data policy spec file is used:
+As an example, consider the following data policy:
 
 ``` yaml
 DATA_POLICIES:
@@ -42,20 +43,26 @@ Running the script above will generate a new global data policy named `policy_1_
 * **action** --> mask fields tagged `tag1` using hashing for everyone except when user is a member of group `group1`
 * **circumstance** --> on data sources with columns tagged `tag1`
 
-Operators allow for stringing together separate conditions, and separate circumstances. The accepted values are `or` and `and`.
+The policy can be configured many ways. However, only the following are currently supported values by `fh-immuta-utils`:
 
-Available types:
-* `Masking` is the only currently implemented `action` and `rule` type.
-* `Groups` is the only currently implemented `condition` type.
-* `columnTags` and `tags` are the only currently implemented `circumstance` types:
-  * `columnTags` applies the policy to data sources with specific column tags
-  * `tags` applies the policy to data sources with specific tags on the data source itself
+1. **Operators**: these allow for stringing together separate conditions, and separate circumstances. The supported values are `or` and `and`.
+2. **Types**:
+    1. `Masking` is the only currently supported `action` and `rule` type.
+    2. `Groups` is the only currently supported `condition` type.
+    3. `columnTags` and `tags` are the only currently supported `circumstance` types:
+        1. `columnTags` applies the policy to data sources with specific column tags
+        2. `tags` applies the policy to data sources with specific tags on the data source itself
 
+## Subscription Policies
 
-The utility also allows creating subscription policies where access to a data source is based on
-membership in a particular IAM group.
+fh-immuta-utils also allows creating subscription policies, where access to a data source is based on
+membership in a particular IAM group. Subscription policies in Immuta dictate who can subscribe to data sources, 
+which allows for querying those data sources. Similar to data policies, they are based on **actions** and **circumstances**:
 
-As an example consider following subscription policy.
+* **Actions** define how the policy restricts, and for whom it restricts.
+* **Circumstances** define where and how the policy is applied to data sources in Immuta.
+
+As an example, consider the following subscription policy:
 
 ```yaml
 SUBSCRIPTION_POLICIES:
@@ -72,7 +79,7 @@ SUBSCRIPTION_POLICIES:
     circumstances:
       - operator: "or"
         type: "tags"
-        tags: ["tag01"] # for data source tagged with "tag01"
+        tags: ["tag01"] # for data sources tagged with "tag01"
 ```
 To apply RBAC based on this policy, you can run the following:
 
@@ -81,11 +88,18 @@ $ conda activate fh-immuta-utils
 $ fh-immuta-utils policies --config-file foo.yml --type subscription
 ```
 
-Running the script above will generate a new global subscription policy named `subscription_1_subscription_policy` that will:
-* **action** --> not subscribe data sources for everyone except when user is a member of group `group01`
-* **circumstance** --> for data sources tagged `tag01`
-
-Operators on conditions and circumstances are same as described above for data policies.
-
-*Note*: To apply both data and subscription policies skip the `--type` argument which defaults to
+*Note*: To apply both data and subscription policies, skip the `--type` argument which defaults to
 both data and subscription policies being applied.
+
+Running the script above will generate a new global subscription policy named `subscription_1_subscription_policy` that will:
+* **action** --> deny subscription except for users who are in the group `group01`
+* **circumstance** --> for data sources tagged with `tag01`
+
+Similar to data policies, subscription policies can be configured many ways. However, only the following are currently supported values by `fh-immuta-utils`:
+
+1. **Operators**: these allow for stringing together separate exceptions, and separate circumstances. The supported values are `or` and `and`.
+2. **Types**:
+    1. `Groups` is the only currently supported `condition` type.
+    2. `columnTags` and `tags` are the only currently supported `circumstance` types:
+        1. `columnTags` applies the policy to data sources with specific column tags
+        2. `tags` applies the policy to data sources with specific tags on the data source itself

--- a/doc/managing_policies.md
+++ b/doc/managing_policies.md
@@ -2,6 +2,8 @@
 
 ## Data Policies
 
+### Configuration and CLI Entrypoint
+
 fh-immuta-utils supports creating global policies to limit access to data sources based on tags.
 The intended use-case is where access to sensitive data is granted on the basis of membership in IAM groups,
 where sensitive columns in data sources are tagged as such.
@@ -38,10 +40,14 @@ To apply RBAC based on this policy, you can run the following:
 $ conda activate fh-immuta-utils
 $ fh-immuta-utils policies --config-file foo.yml --type data
 ```
+*Note*: To apply both data and subscription policies, skip the `--type` argument which defaults to
+both data and subscription policies being applied.
 
 Running the script above will generate a new global data policy named `policy_1_access_policy` that will:
 * **action** --> mask fields tagged `tag1` using hashing for everyone except when user is a member of group `group1`
 * **circumstance** --> on data sources with columns tagged `tag1`
+
+### Supported Values
 
 The policy can be configured many ways. However, only the following are currently supported values by `fh-immuta-utils`:
 
@@ -55,8 +61,10 @@ The policy can be configured many ways. However, only the following are currentl
 
 ## Subscription Policies
 
+### Configuration and CLI Entrypoint
+
 fh-immuta-utils also allows creating subscription policies, where access to a data source is based on
-membership in a particular IAM group. Subscription policies in Immuta dictate who can subscribe to data sources, 
+membership in a particular IAM group. Subscription policies in Immuta dictate who can subscribe to data sources,
 which allows for querying those data sources. Similar to data policies, they are based on **actions** and **circumstances**:
 
 * **Actions** define how the policy restricts, and for whom it restricts.
@@ -66,7 +74,7 @@ As an example, consider the following subscription policy:
 
 ```yaml
 SUBSCRIPTION_POLICIES:
-  subscription_1:
+  subscription_01:
     staged: false
     actions: # do not subscribe to a data source
       - exceptions:
@@ -80,7 +88,10 @@ SUBSCRIPTION_POLICIES:
       - operator: "or"
         type: "tags"
         tags: ["tag01"] # for data sources tagged with "tag01"
+
+
 ```
+
 To apply RBAC based on this policy, you can run the following:
 
 ``` bash
@@ -91,9 +102,11 @@ $ fh-immuta-utils policies --config-file foo.yml --type subscription
 *Note*: To apply both data and subscription policies, skip the `--type` argument which defaults to
 both data and subscription policies being applied.
 
-Running the script above will generate a new global subscription policy named `subscription_1_subscription_policy` that will:
+Running the script above will generate a new global subscription policy named `subscription_01_subscription_policy` that will:
 * **action** --> deny subscription except for users who are in the group `group01`
 * **circumstance** --> for data sources tagged with `tag01`
+
+### Supported Values
 
 Similar to data policies, subscription policies can be configured many ways. However, only the following are currently supported values by `fh-immuta-utils`:
 

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -277,7 +277,7 @@ class ImmutaClient(LoggingMixin):
         post_body = {
             "handler": handlers,
             "dataSource": data_source.dict(by_alias=True, exclude_unset=True),
-            "schemaEvolution": schema_evolution.dict(by_alias=True, exclude_unset=True),
+            "schemaEvolution": schema_evolution.dict(by_alias=False, exclude_unset=True),
         }
         if policy_handler:
             post_body["policyRules"] = policy_handler["jsonPolicies"]

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -522,6 +522,11 @@ class ImmutaClient(LoggingMixin):
         return True
 
     def get_remote_database_test_response(self, dataset_spec: Dict[str, Any]) -> requests.Response:
+        """
+        Tests a remote database enrollment.
+        :param dataset_spec: dataset configuration dictionary
+        :return: test response
+        """
         request_prefix = blob_handler_type(dataset_spec["handler_type"])
         remote_database = dataset_spec["database"]
         headers = self.make_generic_odbc_request_headers(dataset_spec)

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -24,7 +24,8 @@ from .data_source import (
     DataSourceDictionary,
     Handler,
     blob_handler_type,
-    SchemaEvolutionMetadata)
+    SchemaEvolutionMetadata,
+)
 from .policy import GlobalPolicy, make_policy_object_from_json
 from .log import LoggingMixin
 
@@ -521,7 +522,9 @@ class ImmutaClient(LoggingMixin):
         res.raise_for_status()
         return True
 
-    def get_remote_database_test_response(self, dataset_spec: Dict[str, Any]) -> requests.Response:
+    def get_remote_database_test_response(
+        self, dataset_spec: Dict[str, Any]
+    ) -> requests.Response:
         """
         Tests a remote database enrollment.
         :param dataset_spec: dataset configuration dictionary

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -24,7 +24,7 @@ from .data_source import (
     DataSourceDictionary,
     Handler,
     blob_handler_type,
-)
+    SchemaEvolutionMetadata)
 from .policy import GlobalPolicy, make_policy_object_from_json
 from .log import LoggingMixin
 
@@ -257,6 +257,7 @@ class ImmutaClient(LoggingMixin):
         self,
         data_source: DataSource,
         handler: Union[Handler, Sequence[Handler]],
+        schema_evo: SchemaEvolutionMetadata,
         policy_handler=None,
         handler_base_url=None,
         dictionary=None,
@@ -275,6 +276,7 @@ class ImmutaClient(LoggingMixin):
         post_body = {
             "handler": handlers,
             "dataSource": data_source.dict(by_alias=True, skip_defaults=True),
+            "schemaEvolution": schema_evo.dict(by_alias=True, skip_defaults=True),
         }
         if policy_handler:
             post_body["policyRules"] = policy_handler["jsonPolicies"]

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -257,7 +257,7 @@ class ImmutaClient(LoggingMixin):
         self,
         data_source: DataSource,
         handler: Union[Handler, Sequence[Handler]],
-        schema_evo: SchemaEvolutionMetadata,
+        schema_evolution: SchemaEvolutionMetadata,
         policy_handler=None,
         handler_base_url=None,
         dictionary=None,
@@ -276,7 +276,7 @@ class ImmutaClient(LoggingMixin):
         post_body = {
             "handler": handlers,
             "dataSource": data_source.dict(by_alias=True, exclude_unset=True),
-            "schemaEvolution": schema_evo.dict(by_alias=True, exclude_unset=True),
+            "schemaEvolution": schema_evolution.dict(by_alias=True, exclude_unset=True),
         }
         if policy_handler:
             post_body["policyRules"] = policy_handler["jsonPolicies"]
@@ -520,6 +520,14 @@ class ImmutaClient(LoggingMixin):
         res = self._session.post(f"tag/datasource/{id}", json=tag_data)
         res.raise_for_status()
         return True
+
+    def get_database_test_response(self, dataset_spec: Dict[str, Any]) -> requests.Response:
+        request_prefix = blob_handler_type(dataset_spec["handler_type"])
+        remote_database = dataset_spec["database"]
+        headers = self.make_generic_odbc_request_headers(dataset_spec)
+        res = self.get(f"{request_prefix}/database/{remote_database}/test", headers=headers)
+
+        return res
 
 
 def get_client(base_url: str, auth_config: Dict[str, Any], **kwargs) -> ImmutaClient:

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -277,7 +277,9 @@ class ImmutaClient(LoggingMixin):
         post_body = {
             "handler": handlers,
             "dataSource": data_source.dict(by_alias=True, exclude_unset=True),
-            "schemaEvolution": schema_evolution.dict(by_alias=False, exclude_unset=True),
+            "schemaEvolution": schema_evolution.dict(
+                by_alias=False, exclude_unset=True
+            ),
         }
         if policy_handler:
             post_body["policyRules"] = policy_handler["jsonPolicies"]

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -529,7 +529,7 @@ class ImmutaClient(LoggingMixin):
         res = self._session.get(path, headers=headers)
         return res
 
-    def get_current_user_information(self) -> requests.Response:
+    def get_current_user_information(self) -> Dict[str, Any]:
         return self.get("/bim/rpc/user/current")
 
 

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -521,13 +521,16 @@ class ImmutaClient(LoggingMixin):
         res.raise_for_status()
         return True
 
-    def get_database_test_response(self, dataset_spec: Dict[str, Any]) -> requests.Response:
+    def get_remote_database_test_response(self, dataset_spec: Dict[str, Any]) -> requests.Response:
         request_prefix = blob_handler_type(dataset_spec["handler_type"])
         remote_database = dataset_spec["database"]
         headers = self.make_generic_odbc_request_headers(dataset_spec)
-        res = self.get(f"{request_prefix}/database/{remote_database}/test", headers=headers)
-
+        path = f"{request_prefix}/database/{remote_database}/test"
+        res = self._session.get(path, headers=headers)
         return res
+
+    def get_current_user_information(self) -> requests.Response:
+        return self.get("/bim/rpc/user/current")
 
 
 def get_client(base_url: str, auth_config: Dict[str, Any], **kwargs) -> ImmutaClient:

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -238,7 +238,7 @@ class ImmutaClient(LoggingMixin):
         self, id: int, dictionary: DataSourceDictionary
     ) -> bool:
         res = self._session.put(
-            f"dictionary/{id}", data=dictionary.json(skip_defaults=True)
+            f"dictionary/{id}", data=dictionary.json(exclude_unset=True)
         )
         res.raise_for_status()
         return True
@@ -265,9 +265,9 @@ class ImmutaClient(LoggingMixin):
         request_prefix = blob_handler_type(data_source.blobHandlerType)
         is_bulk_insert = isinstance(handler, list)
         if is_bulk_insert:
-            handlers = [h.dict(by_alias=True, skip_defaults=True) for h in handler]
+            handlers = [h.dict(by_alias=True, exclude_unset=True) for h in handler]
         elif isinstance(handler, Handler):  # type check here to make mypy happy
-            handlers = handler.dict(by_alias=True, skip_defaults=True)
+            handlers = handler.dict(by_alias=True, exclude_unset=True)
         else:
             raise RuntimeError(
                 "Invalid format for given blob handler. Expected either a list or a"
@@ -275,8 +275,8 @@ class ImmutaClient(LoggingMixin):
             )
         post_body = {
             "handler": handlers,
-            "dataSource": data_source.dict(by_alias=True, skip_defaults=True),
-            "schemaEvolution": schema_evo.dict(by_alias=True, skip_defaults=True),
+            "dataSource": data_source.dict(by_alias=True, exclude_unset=True),
+            "schemaEvolution": schema_evo.dict(by_alias=True, exclude_unset=True),
         }
         if policy_handler:
             post_body["policyRules"] = policy_handler["jsonPolicies"]

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -48,7 +48,7 @@ def make_table_name(
     handler_type: str, schema: str, table: str, user_prefix: Optional[str]
 ) -> str:
     """
-    Returns table name with format <handler_prefix>_<schema>_<table>. <user_prefix>_ is prepended if provided.
+    Returns table name with format <handler_prefix>_<schema>_<table>. If provided, <user_prefix>_ is prepended.
     """
     table_name = ""
     if user_prefix:
@@ -283,17 +283,17 @@ def make_handler_metadata(
 
 
 def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMetadata:
-    name_default = f"{PREFIX_MAP[config['handler_type']]}_<schema>_<tablename>"
-    table_default = f"{PREFIX_MAP[config['handler_type']]}_<schema>_<tablename>"
-    schema_default = "<schema>"
+    name_format_default = f"{PREFIX_MAP[config['handler_type']]}_<schema>_<tablename>"
+    table_format_default = f"{PREFIX_MAP[config['handler_type']]}_<schema>_<tablename>"
+    schema_format_default = "<schema>"
     return SchemaEvolutionMetadata(
         ownerProfileId=config["owner_profile_id"],
         disabled=config.get("schema_evolution", True).get("disable_schema_evolution", True),
         config=SchemaEvolutionMetadataConfig(
             nameTemplate={
-                "nameFormat": config.get("schema_evolution", name_default).get("immuta_name_format", name_default),
-                "tableFormat": config.get("schema_evolution", table_default).get("sql_table_name_format", table_default),
-                "sqlSchemaNameFormat": config.get("schema_evolution", schema_default).get("sql_schema_name_format", schema_default),
+                "nameFormat": config.get("schema_evolution", name_format_default).get("immuta_name_format", name_format_default),
+                "tableFormat": config.get("schema_evolution", table_format_default).get("sql_table_name_format", table_format_default),
+                "sqlSchemaNameFormat": config.get("schema_evolution", schema_format_default).get("sql_schema_name_format", schema_format_default),
             }
         )
     )

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -237,7 +237,7 @@ def make_bulk_create_objects(
         blobHandlerType=config["handler_type"], recordFormat="json", type="queryable"
     )
     schema_evo = SchemaEvolutionMetadata(
-        disabled=not config["schema_evolution"], ownerProfileId=0  # TODO: fix
+        disabled=config["disable_schema_evolution"], ownerProfileId=0  # TODO: fix
     )
     return ds, handlers, schema_evo
 
@@ -282,7 +282,7 @@ def to_immuta_objects(
         # owner="foo",
     )
     schema_evo = SchemaEvolutionMetadata(
-        disabled=not config["schema_evolution"], ownerProfileId=0  # TODO: fix
+        disabled=config["disable_schema_evolution"], ownerProfileId=0  # TODO: fix
     )
     return ds, handler, schema_evo
 

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -227,7 +227,7 @@ def make_bulk_create_objects(
             user_prefix=user_prefix,
         )
         immuta_datasource_name = make_immuta_datasource_name(
-            handler_type=["handler_type"],
+            handler_type=config["handler_type"],
             schema=schema,
             table=table,
             user_prefix=user_prefix,
@@ -267,7 +267,7 @@ def to_immuta_objects(
         user_prefix=user_prefix,
     )
     immuta_datasource_name = make_immuta_datasource_name(
-        handler_type=["handler_type"],
+        handler_type=config["handler_type"],
         schema=schema,
         table=table,
         user_prefix=user_prefix,

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -130,9 +130,9 @@ class DataSource(BaseModel):
 
 
 class SchemaEvolutionMetadataConfigTemplate(BaseModel):
-    nameFormat: str = Field(..., alias='dataSourceNameFormat')
-    tableFormat: str = Field(..., alias='queryEngineTableNameFormat')
-    sqlSchemaNameFormat: str = Field(..., alias='queryEngineSchemaNameFormat')
+    nameFormat: str = Field(..., alias="dataSourceNameFormat")
+    tableFormat: str = Field(..., alias="queryEngineTableNameFormat")
+    sqlSchemaNameFormat: str = Field(..., alias="queryEngineSchemaNameFormat")
 
 
 class SchemaEvolutionMetadataConfig(BaseModel):
@@ -340,7 +340,9 @@ def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMet
     if config.get("prefix"):
         user_prefix = f"{config.get('prefix')}_"
     handler_prefix = PREFIX_MAP[config["handler_type"]]
-    datasource_name_format_default = f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
+    datasource_name_format_default = (
+        f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
+    )
     query_engine_table_name_format_default = (
         f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
     )
@@ -357,10 +359,12 @@ def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMet
                     "datasource_name_format", datasource_name_format_default
                 ),
                 queryEngineTableNameFormat=config.get("schema_evolution", {}).get(
-                    "query_engine_table_name_format", query_engine_table_name_format_default
+                    "query_engine_table_name_format",
+                    query_engine_table_name_format_default,
                 ),
                 queryEngineSchemaNameFormat=config.get("schema_evolution", {}).get(
-                    "query_engine_schema_name_format", query_engine_schema_name_format_default
+                    "query_engine_schema_name_format",
+                    query_engine_schema_name_format_default,
                 ),
             )
         ),

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -288,12 +288,12 @@ def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMet
     schema_format_default = "<schema>"
     return SchemaEvolutionMetadata(
         ownerProfileId=config["owner_profile_id"],
-        disabled=config.get("schema_evolution", True).get("disable_schema_evolution", True),
+        disabled=config.get("schema_evolution", {}).get("disable_schema_evolution", True),
         config=SchemaEvolutionMetadataConfig(
             nameTemplate={
-                "nameFormat": config.get("schema_evolution", name_format_default).get("immuta_name_format", name_format_default),
-                "tableFormat": config.get("schema_evolution", table_format_default).get("sql_table_name_format", table_format_default),
-                "sqlSchemaNameFormat": config.get("schema_evolution", schema_format_default).get("sql_schema_name_format", schema_format_default),
+                "nameFormat": config.get("schema_evolution", {}).get("immuta_name_format", name_format_default),
+                "tableFormat": config.get("schema_evolution", {}).get("sql_table_name_format", table_format_default),
+                "sqlSchemaNameFormat": config.get("schema_evolution", {}).get("sql_schema_name_format", schema_format_default),
             }
         )
     )

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -128,6 +128,20 @@ class DataSource(BaseModel):
     useDatesAsDirectory: bool = False
 
 
+class SchemaEvolutionMetadataConfig(BaseModel):
+    nameTemplate: Dict[str, str] = {
+        "nameFormat": str,
+        "tableFormat": str,
+        "sqlSchemaNameFormat": str
+    }
+
+
+class SchemaEvolutionMetadata(BaseModel):
+    disabled: bool = True
+    ownerProfileId: int
+    config: Optional[SchemaEvolutionMetadataConfig] = None
+
+
 class DataSourceColumn(BaseModel):
     name: str
     dataType: str
@@ -222,7 +236,10 @@ def make_bulk_create_objects(
     ds = DataSource(
         blobHandlerType=config["handler_type"], recordFormat="json", type="queryable"
     )
-    return (ds, handlers)
+    schema_evo = SchemaEvolutionMetadata(
+        disabled=not config["schema_evolution"], ownerProfileId=0  # TODO: fix
+    )
+    return ds, handlers, schema_evo
 
 
 def to_immuta_objects(
@@ -264,7 +281,10 @@ def to_immuta_objects(
         description="bar",
         # owner="foo",
     )
-    return (ds, handler)
+    schema_evo = SchemaEvolutionMetadata(
+        disabled=not config["schema_evolution"], ownerProfileId=0  # TODO: fix
+    )
+    return ds, handler, schema_evo
 
 
 def make_handler_metadata(

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -128,12 +128,14 @@ class DataSource(BaseModel):
     useDatesAsDirectory: bool = False
 
 
+class SchemaEvolutionMetadataConfigNameTemplate(BaseModel):
+    nameFormat: str
+    tableFormat: str
+    sqlSchemaNameFormat: str
+
+
 class SchemaEvolutionMetadataConfig(BaseModel):
-    nameTemplate: Dict[str, str] = {
-        "nameFormat": str,
-        "tableFormat": str,
-        "sqlSchemaNameFormat": str
-    }
+    nameTemplate: SchemaEvolutionMetadataConfigNameTemplate
 
 
 class SchemaEvolutionMetadata(BaseModel):
@@ -236,10 +238,10 @@ def make_bulk_create_objects(
     ds = DataSource(
         blobHandlerType=config["handler_type"], recordFormat="json", type="queryable"
     )
-    schema_evo = SchemaEvolutionMetadata(
+    schema_evolution = SchemaEvolutionMetadata(
         disabled=config["disable_schema_evolution"], ownerProfileId=0  # TODO: fix
     )
-    return ds, handlers, schema_evo
+    return ds, handlers, schema_evolution
 
 
 def to_immuta_objects(
@@ -281,10 +283,10 @@ def to_immuta_objects(
         description="bar",
         # owner="foo",
     )
-    schema_evo = SchemaEvolutionMetadata(
+    schema_evolution = SchemaEvolutionMetadata(
         disabled=config["disable_schema_evolution"], ownerProfileId=0  # TODO: fix
     )
-    return ds, handler, schema_evo
+    return ds, handler, schema_evolution
 
 
 def make_handler_metadata(

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -283,17 +283,28 @@ def make_handler_metadata(
 
 
 def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMetadata:
-    name_format_default = f"{PREFIX_MAP[config['handler_type']]}_<schema>_<tablename>"
-    table_format_default = f"{PREFIX_MAP[config['handler_type']]}_<schema>_<tablename>"
-    schema_format_default = "<schema>"
+    """
+    Builds metadata for the schema evolution object. Immuta table name and SQL table name template defaults match the
+    pattern defined in make_table_name()
+    :param config: dataset configuration dictionary
+    :return: SchemaEvolutionMetadata object
+    """
+    user_prefix = ""
+    if config.get("prefix"):
+        user_prefix = f"{config.get('prefix')}_"
+    handler_prefix = PREFIX_MAP[config['handler_type']]
+    immuta_name_format_default = f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
+    sql_table_name_format_default = f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
+    sql_schema_name_format_default = "<schema>"
+
     return SchemaEvolutionMetadata(
         ownerProfileId=config["owner_profile_id"],
         disabled=config.get("schema_evolution", {}).get("disable_schema_evolution", True),
         config=SchemaEvolutionMetadataConfig(
             nameTemplate={
-                "nameFormat": config.get("schema_evolution", {}).get("immuta_name_format", name_format_default),
-                "tableFormat": config.get("schema_evolution", {}).get("sql_table_name_format", table_format_default),
-                "sqlSchemaNameFormat": config.get("schema_evolution", {}).get("sql_schema_name_format", schema_format_default),
+                "nameFormat": config.get("schema_evolution", {}).get("immuta_name_format", immuta_name_format_default),
+                "tableFormat": config.get("schema_evolution", {}).get("sql_table_name_format", sql_table_name_format_default),
+                "sqlSchemaNameFormat": config.get("schema_evolution", {}).get("sql_schema_name_format", sql_schema_name_format_default),
             }
         )
     )

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -139,8 +139,8 @@ class SchemaEvolutionMetadataConfig(BaseModel):
 
 
 class SchemaEvolutionMetadata(BaseModel):
-    disabled: bool = True
     ownerProfileId: int
+    disabled: bool = True
     config: Optional[SchemaEvolutionMetadataConfig] = None
 
 
@@ -239,7 +239,7 @@ def make_bulk_create_objects(
         blobHandlerType=config["handler_type"], recordFormat="json", type="queryable"
     )
     schema_evolution = SchemaEvolutionMetadata(
-        disabled=config["disable_schema_evolution"], ownerProfileId=0  # TODO: fix
+        ownerProfileId=config["owner_profile_id"], disabled=config["disable_schema_evolution"],  # TODO: fix
     )
     return ds, handlers, schema_evolution
 
@@ -284,7 +284,7 @@ def to_immuta_objects(
         # owner="foo",
     )
     schema_evolution = SchemaEvolutionMetadata(
-        disabled=config["disable_schema_evolution"], ownerProfileId=0  # TODO: fix
+        ownerProfileId=config["owner_profile_id"], disabled=config["disable_schema_evolution"],  # TODO: fix
     )
     return ds, handler, schema_evolution
 

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -1,7 +1,7 @@
 from typing import Dict, Any, Optional, List, Tuple
 import logging
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 LOGGER = logging.getLogger(__name__)
 
@@ -97,9 +97,9 @@ class DataSource(BaseModel):
 
 
 class SchemaEvolutionMetadataConfigTemplate(BaseModel):
-    nameFormat: str
-    tableFormat: str
-    sqlSchemaNameFormat: str
+    nameFormat: str = Field(..., alias='dataSourceNameFormat')
+    tableFormat: str = Field(..., alias='queryEngineTableNameFormat')
+    sqlSchemaNameFormat: str = Field(..., alias='queryEngineSchemaNameFormat')
 
 
 class SchemaEvolutionMetadataConfig(BaseModel):
@@ -295,11 +295,11 @@ def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMet
     if config.get("prefix"):
         user_prefix = f"{config.get('prefix')}_"
     handler_prefix = PREFIX_MAP[config["handler_type"]]
-    immuta_name_format_default = f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
-    sql_table_name_format_default = (
+    datasource_name_format_default = f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
+    query_engine_table_name_format_default = (
         f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
     )
-    sql_schema_name_format_default = "<schema>"
+    query_engine_schema_name_format_default = "<schema>"
 
     return SchemaEvolutionMetadata(
         ownerProfileId=config["owner_profile_id"],
@@ -308,14 +308,14 @@ def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMet
         ),
         config=SchemaEvolutionMetadataConfig(
             nameTemplate=SchemaEvolutionMetadataConfigTemplate(
-                nameFormat=config.get("schema_evolution", {}).get(
-                    "immuta_name_format", immuta_name_format_default
+                dataSourceNameFormat=config.get("schema_evolution", {}).get(
+                    "datasource_name_format", datasource_name_format_default
                 ),
-                tableFormat=config.get("schema_evolution", {}).get(
-                    "sql_table_name_format", sql_table_name_format_default
+                queryEngineTableNameFormat=config.get("schema_evolution", {}).get(
+                    "query_engine_table_name_format", query_engine_table_name_format_default
                 ),
-                sqlSchemaNameFormat=config.get("schema_evolution", {}).get(
-                    "sql_schema_name_format", sql_schema_name_format_default
+                queryEngineSchemaNameFormat=config.get("schema_evolution", {}).get(
+                    "query_engine_schema_name_format", query_engine_schema_name_format_default
                 ),
             )
         ),

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -38,8 +38,6 @@ PREFIX_MAP = {
     "Amazon S3": "s3",
     "Amazon Athena": "ath",
 }
-MAX_IMMUTA_NAME_LIMIT = 55
-MAX_POSTGRES_NAME_LIMIT = 63
 
 
 def blob_handler_type(handler_type: str) -> str:
@@ -50,7 +48,7 @@ def make_immuta_table_name(
     handler_type: str, schema: str, table: str, user_prefix: Optional[str]
 ) -> str:
     """
-    Returns a table name that's guaranteed to be unique and within the max char limit (55)
+    Returns a table name that's guaranteed to be unique
     """
     table_name = ""
     if user_prefix:
@@ -58,35 +56,20 @@ def make_immuta_table_name(
     table_name += f"{PREFIX_MAP[handler_type]}_{schema}_{table}"
     if table_name is None:
         return None
-    if len(table_name) <= MAX_IMMUTA_NAME_LIMIT:
-        return table_name
-    import hashlib
-
-    return (
-        table_name[: MAX_IMMUTA_NAME_LIMIT - 8]
-        + hashlib.md5(table_name.encode()).hexdigest()[:8]
-    )
+    return table_name
 
 
 def make_postgres_table_name(
     handler_type: str, schema: str, table: str, user_prefix: Optional[str]
 ) -> str:
     """
-    Returns table name that has a shortened prefix and conforms to the Postgres max char limit (63)
+    Returns table name that has a shortened prefix
     """
     table_name = ""
     if user_prefix:
         table_name = f"{user_prefix}_"
     table_name += f"{PREFIX_MAP[handler_type]}_{schema}_{table}"
-    if len(table_name) < MAX_POSTGRES_NAME_LIMIT:
-        return table_name
-    trunc_table_name = table_name[:MAX_POSTGRES_NAME_LIMIT]
-    LOGGER.warning(
-        "Postgres table name too long! Table %s truncated to %s",
-        table_name,
-        trunc_table_name,
-    )
-    return trunc_table_name
+    return table_name
 
 
 class BlobHandler(BaseModel):

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -215,14 +215,20 @@ def is_schema_evolution_enabled(client: "ImmutaClient", dataset_spec: Dict[str, 
 
 
 def skip_dataset_enrollment(client: "ImmutaClient", dataset_spec: Dict[str, Any]) -> bool:
-    # skip enrollment if remote database is already enrolled, schema evolution is enabled, and config does not disable
-    # schema evolution
     disable_schema_evolution = dataset_spec.get("schema_evolution", True).get("disable_schema_evolution", True)
     schema_evolution_status = is_schema_evolution_enabled(client, dataset_spec)
+    # skip enrollment if remote database is already enrolled, schema evolution is enabled, and config does not disable
+    # schema evolution
     if schema_evolution_status and not disable_schema_evolution:
         LOGGER.info(
-            f"{dataset_spec['hostname']}/{dataset_spec['database']} is already enrolled and monitoring for schema changes. Skipping.")  # TODO: Fix
+            f"{dataset_spec['hostname']}/{dataset_spec['database']} is already enrolled and monitoring for schema "
+            f"changes. Skipping enrollment.")
         return True
+
+    if not schema_evolution_status and not disable_schema_evolution:
+        LOGGER.info(f"Enabling schema evolution for {dataset_spec['hostname']}/{dataset_spec['database']}")
+    if schema_evolution_status and disable_schema_evolution:
+        LOGGER.info(f"Disabling schema evolution for {dataset_spec['hostname']}/{dataset_spec['database']}")
 
     return False
 

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -207,6 +207,12 @@ def create_data_source(
 
 
 def is_schema_evolution_enabled(client: "ImmutaClient", dataset_spec: Dict[str, Any]) -> bool:
+    """
+    Determines if schema evolution is enabled for the remote database.
+    :param client: authenticated Immuta client
+    :param dataset_spec: dataset configuration dictionary
+    :return: bool
+    """
     res = client.get_remote_database_test_response(dataset_spec)
     res_data = res.json()
     if res.status_code == 200 and "existingSchemaEvolutionRecord" in res_data:
@@ -217,6 +223,12 @@ def is_schema_evolution_enabled(client: "ImmutaClient", dataset_spec: Dict[str, 
 
 
 def skip_dataset_enrollment(client: "ImmutaClient", dataset_spec: Dict[str, Any]) -> bool:
+    """
+    Evaluates scenarios to determine if dataset enrollment should be skipped.
+    :param client: authenticated Immuta client
+    :param dataset_spec: dataset configuration dictionary
+    :return: bool
+    """
     disable_schema_evolution = dataset_spec.get("schema_evolution", {}).get("disable_schema_evolution", True)
     schema_evolution_status = is_schema_evolution_enabled(client, dataset_spec)
     # skip enrollment if remote database is already enrolled, schema evolution is enabled, and config does not disable

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -189,7 +189,7 @@ def data_sources_bulk_enroll_iterator(
             schema=schema,
             tables=[table["tableName"] for table in tables],
             config=config,
-            user_prefix=config.get("prefix"),
+            user_prefix=config.get("user_prefix"),
         )
         yield data_source, handlers, schema_evolution
 

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -30,7 +30,7 @@ from fh_immuta_utils.data_source import (
     to_immuta_objects,
     make_handler_metadata,
     make_bulk_create_objects,
-)
+    SchemaEvolutionMetadata)
 
 if TYPE_CHECKING:
     from fh_immuta_utils.client import ImmutaClient
@@ -88,7 +88,7 @@ def main(config_file: str, glob_prefix: str, debug: bool, dry_run: bool) -> bool
             if not schemas:
                 continue
             for schema_object in schemas:
-                for (data_source, handler) in enroll_iter(  # type: ignore
+                for (data_source, handler, schema_evo) in enroll_iter(  # type: ignore
                     client=client,
                     schema_table_mapping=schema_table_mapping,
                     schema_obj=schema_object,
@@ -105,7 +105,7 @@ def main(config_file: str, glob_prefix: str, debug: bool, dry_run: bool) -> bool
                         )
                     if not dry_run:
                         if not create_data_source(
-                            client=client, data_source=data_source, handler=handler
+                            client=client, data_source=data_source, handler=handler, schema_evo=schema_evo
                         ):
                             failed_tables.add(data_source.name)
         if failed_tables:
@@ -152,10 +152,10 @@ def data_sources_enroll_iterator(
                 config=config, data_source_type=config["handler_type"], handler=handler
             )
 
-            data_source, handler = to_immuta_objects(
+            data_source, handler, schema_evo = to_immuta_objects(
                 schema=schema, table=table["tableName"], columns=columns, config=config
             )
-            yield (data_source, handler)
+            yield (data_source, handler, schema_evo)
 
 
 def data_sources_bulk_enroll_iterator(
@@ -174,22 +174,23 @@ def data_sources_bulk_enroll_iterator(
         if len(tables) == 0:
             LOGGER.warning("No tables found for schema: %s", schema)
             continue
-        data_source, handlers = make_bulk_create_objects(
+        data_source, handlers, schema_evo = make_bulk_create_objects(
             schema=schema,
             tables=[table["tableName"] for table in tables],
             config=config,
             user_prefix=config.get("prefix"),
         )
-        yield (data_source, handlers)
+        yield (data_source, handlers, schema_evo)
 
 
 def create_data_source(
     client: "ImmutaClient",
     data_source: DataSource,
     handler: Union[Handler, List[Handler]],
+    schema_evo: SchemaEvolutionMetadata,
 ) -> bool:
     try:
-        result = client.create_data_source(data_source, handler)
+        result = client.create_data_source(data_source, handler, schema_evo)
         if result:
             LOGGER.info(
                 "Created data source %s, id: %d", data_source.name, result["id"]

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -160,7 +160,7 @@ def data_sources_enroll_iterator(
             data_source, handler, schema_evolution = to_immuta_objects(
                 schema=schema, table=table["tableName"], columns=columns, config=config
             )
-            yield (data_source, handler, schema_evolution)
+            yield data_source, handler, schema_evolution
 
 
 def data_sources_bulk_enroll_iterator(
@@ -185,7 +185,7 @@ def data_sources_bulk_enroll_iterator(
             config=config,
             user_prefix=config.get("prefix"),
         )
-        yield (data_source, handlers, schema_evolution)
+        yield data_source, handlers, schema_evolution
 
 
 def create_data_source(
@@ -217,7 +217,7 @@ def is_schema_evolution_enabled(client: "ImmutaClient", dataset_spec: Dict[str, 
 def skip_dataset_enrollment(client: "ImmutaClient", dataset_spec: Dict[str, Any]) -> bool:
     # skip enrollment if remote database is already enrolled, schema evolution is enabled, and config does not disable
     # schema evolution
-    disable_schema_evolution = dataset_spec.get("disable_schema_evolution", True)
+    disable_schema_evolution = dataset_spec.get("schema_evolution", True).get("disable_schema_evolution", True)
     schema_evolution_status = is_schema_evolution_enabled(client, dataset_spec)
     if schema_evolution_status and not disable_schema_evolution:
         LOGGER.info(

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -208,14 +208,16 @@ def create_data_source(
 
 def is_schema_evolution_enabled(client: "ImmutaClient", dataset_spec: Dict[str, Any]) -> bool:
     res = client.get_remote_database_test_response(dataset_spec)
-    if res.status_code == 200 and "existingSchemaEvolutionRecord" in res.json():
-        return True
+    res_data = res.json()
+    if res.status_code == 200 and "existingSchemaEvolutionRecord" in res_data:
+        if not res_data["existingSchemaEvolutionRecord"]["disabled"]:
+            return True
 
     return False
 
 
 def skip_dataset_enrollment(client: "ImmutaClient", dataset_spec: Dict[str, Any]) -> bool:
-    disable_schema_evolution = dataset_spec.get("schema_evolution", True).get("disable_schema_evolution", True)
+    disable_schema_evolution = dataset_spec.get("schema_evolution", {}).get("disable_schema_evolution", True)
     schema_evolution_status = is_schema_evolution_enabled(client, dataset_spec)
     # skip enrollment if remote database is already enrolled, schema evolution is enabled, and config does not disable
     # schema evolution

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -111,13 +111,13 @@ class Tagger(object):
     ) -> Dict[str, Any]:
         if not children:
             return {
-                "tags": [Tag(name=root_tag).dict(by_alias=True, skip_defaults=True)]
+                "tags": [Tag(name=root_tag).dict(by_alias=True, exclude_unset=True)]
             }
 
         return {
             "rootTag": {"name": root_tag, "deleteHierarchy": False},
             "tags": [
-                Tag(name=child).dict(by_alias=True, skip_defaults=True)
+                Tag(name=child).dict(by_alias=True, exclude_unset=True)
                 for child in children
             ],
         }

--- a/fh_immuta_utils/tests/test_data_source.py
+++ b/fh_immuta_utils/tests/test_data_source.py
@@ -60,9 +60,7 @@ def test_make_table_name(
     name = ds.make_table_name(
         handler_type=handler_type, schema=schema, table=table, user_prefix=user_prefix
     )
-    assert (
-        name == expected_name
-    )
+    assert name == expected_name
 
 
 MetadataTestKeys = namedtuple(
@@ -180,7 +178,12 @@ def test_to_immuta_objects(
     expected_type: Any,
     columns: List[ds.DataSourceColumn],
 ):
-    base_config = {"username": "foo", "password": "bar", "database": "baz", "owner_profile_id": 0}
+    base_config = {
+        "username": "foo",
+        "password": "bar",
+        "database": "baz",
+        "owner_profile_id": 0,
+    }
     config = {**base_config, **db_keys}
     config["handler_type"] = handler_type
     source, handler, schema_evolution = ds.to_immuta_objects(
@@ -238,7 +241,12 @@ BULK_OBJECT_TESTS = [
 def test_make_bulk_create_objects(
     db_keys: Dict[str, str], handler_type: str, expected_type: Any, tables: List[str]
 ):
-    base_config = {"username": "foo", "password": "bar", "database": "baz", "owner_profile_id": 0}
+    base_config = {
+        "username": "foo",
+        "password": "bar",
+        "database": "baz",
+        "owner_profile_id": 0,
+    }
     config = {**base_config, **db_keys}
     config["handler_type"] = handler_type
 
@@ -264,6 +272,7 @@ def test_make_bulk_create_objects(
 
     assert isinstance(schema_evolution, ds.SchemaEvolutionMetadata)
 
+
 SCHEMA_EVOLUTION_METADATA_TESTS = {
     "schema_evolution_no_config": (
         {
@@ -279,8 +288,8 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
                     "tableFormat": "rs_<schema>_<tablename>",
                     "sqlSchemaNameFormat": "<schema>",
                 }
-            )
-        )
+            ),
+        ),
     ),
     "schema_evolution_no_config_change_handler": (
         {
@@ -296,8 +305,8 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
                     "tableFormat": "ath_<schema>_<tablename>",
                     "sqlSchemaNameFormat": "<schema>",
                 }
-            )
-        )
+            ),
+        ),
     ),
     "schema_evolution_disabled": (
         {
@@ -308,7 +317,7 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
                 "immuta_name_format": "foo",
                 "sql_table_name_format": "bar",
                 "sql_schema_name_format": "biz",
-            }
+            },
         },
         ds.SchemaEvolutionMetadata(
             ownerProfileId=0,
@@ -319,8 +328,8 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
                     "tableFormat": "bar",
                     "sqlSchemaNameFormat": "biz",
                 }
-            )
-        )
+            ),
+        ),
     ),
     "schema_evolution_enabled": (
         {
@@ -331,7 +340,7 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
                 "immuta_name_format": "foo",
                 "sql_table_name_format": "bar",
                 "sql_schema_name_format": "biz",
-            }
+            },
         },
         ds.SchemaEvolutionMetadata(
             ownerProfileId=0,
@@ -342,15 +351,23 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
                     "tableFormat": "bar",
                     "sqlSchemaNameFormat": "biz",
                 }
-            )
-        )
+            ),
+        ),
     ),
 }
 
 
-@pytest.mark.parametrize("config, expected", list(SCHEMA_EVOLUTION_METADATA_TESTS.values()), ids=list(SCHEMA_EVOLUTION_METADATA_TESTS.keys()))
-def test_make_schema_evolution_metadata(config: Dict[str, Any], expected: ds.SchemaEvolutionMetadata):
-    assert isinstance(ds.make_schema_evolution_metadata(config), ds.SchemaEvolutionMetadata)
+@pytest.mark.parametrize(
+    "config, expected",
+    list(SCHEMA_EVOLUTION_METADATA_TESTS.values()),
+    ids=list(SCHEMA_EVOLUTION_METADATA_TESTS.keys()),
+)
+def test_make_schema_evolution_metadata(
+    config: Dict[str, Any], expected: ds.SchemaEvolutionMetadata
+):
+    assert isinstance(
+        ds.make_schema_evolution_metadata(config), ds.SchemaEvolutionMetadata
+    )
     assert ds.make_schema_evolution_metadata(config) == expected
 
 
@@ -360,44 +377,50 @@ SKIP_DATASET_ENROLLMENT_TESTS = {
             "is_schema_evolution_enabled": True,
             "schema_evolution": {
                 "disable_schema_evolution": False,
-            }
+            },
         },
-        True
+        True,
     ),
     "schema_evolution_enabled_config_disabled": (
         {
             "is_schema_evolution_enabled": True,
             "schema_evolution": {
                 "disable_schema_evolution": True,
-            }
+            },
         },
-        False
+        False,
     ),
     "schema_evolution_disabled_config_disabled": (
         {
             "is_schema_evolution_enabled": False,
             "schema_evolution": {
                 "disable_schema_evolution": True,
-            }
+            },
         },
-        False
+        False,
     ),
     "schema_evolution_disabled_config_enabled": (
         {
             "is_schema_evolution_enabled": False,
             "schema_evolution": {
                 "disable_schema_evolution": False,
-            }
+            },
         },
-        False
-    )
+        False,
+    ),
 }
 
 
-@pytest.mark.parametrize("config, expected", list(SKIP_DATASET_ENROLLMENT_TESTS.values()), ids=list(SKIP_DATASET_ENROLLMENT_TESTS.keys()))
+@pytest.mark.parametrize(
+    "config, expected",
+    list(SKIP_DATASET_ENROLLMENT_TESTS.values()),
+    ids=list(SKIP_DATASET_ENROLLMENT_TESTS.keys()),
+)
 @patch("fh_immuta_utils.scripts.manage_data_sources.is_schema_evolution_enabled")
 def test_skip_dataset_enrollment(mock_is_schema_evolution_enabled, config, expected):
     config["hostname"] = "redshift.foobar.io"
     config["database"] = "data"
-    mock_is_schema_evolution_enabled.return_value = config["is_schema_evolution_enabled"]
+    mock_is_schema_evolution_enabled.return_value = config[
+        "is_schema_evolution_enabled"
+    ]
     assert skip_dataset_enrollment(None, config) == expected

--- a/fh_immuta_utils/tests/test_data_source.py
+++ b/fh_immuta_utils/tests/test_data_source.py
@@ -26,24 +26,6 @@ IMMUTA_NAME_TESTS = [
         expected_name=f"quuz_{ds.PREFIX_MAP['PostgreSQL']}_foo_barbazquxquux",
     ),
     NameTestKeys(
-        handler_type="PostgreSQL",
-        schema="foo",
-        table=f"{'a'*(ds.MAX_IMMUTA_NAME_LIMIT - 7)}",
-        user_prefix="",
-        expected_name=(
-            f"{ds.PREFIX_MAP['PostgreSQL']}_foo_{'a'*(ds.MAX_IMMUTA_NAME_LIMIT - 7)}"
-        ),
-    ),
-    NameTestKeys(
-        handler_type="PostgreSQL",
-        schema="foo",
-        table=f"{'a'*ds.MAX_IMMUTA_NAME_LIMIT}",
-        user_prefix="",
-        expected_name=(
-            f"{ds.PREFIX_MAP['PostgreSQL']}_foo_{'a'*(ds.MAX_IMMUTA_NAME_LIMIT - 7)}"
-        ),
-    ),
-    NameTestKeys(
         handler_type="Redshift",
         schema="foo",
         table="barbazquxquux",
@@ -82,24 +64,6 @@ POSTGRES_NAME_TESTS = [
         expected_name=f"quuz_{ds.PREFIX_MAP['PostgreSQL']}_foo_barbazquxquux",
     ),
     NameTestKeys(
-        handler_type="PostgreSQL",
-        schema="foo",
-        table=f"{'a'*(ds.MAX_POSTGRES_NAME_LIMIT - 7)}",
-        user_prefix="",
-        expected_name=(
-            f"{ds.PREFIX_MAP['PostgreSQL']}_foo_{'a'*(ds.MAX_POSTGRES_NAME_LIMIT - 7)}"
-        ),
-    ),
-    NameTestKeys(
-        handler_type="PostgreSQL",
-        schema="foo",
-        table=f"{'a'*ds.MAX_POSTGRES_NAME_LIMIT}",
-        user_prefix="",
-        expected_name=(
-            f"{ds.PREFIX_MAP['PostgreSQL']}_foo_{'a'*(ds.MAX_POSTGRES_NAME_LIMIT - 7)}"
-        ),
-    ),
-    NameTestKeys(
         handler_type="Redshift",
         schema="foo",
         table="barbazquxquux",
@@ -132,10 +96,8 @@ def test_make_immuta_table_name(
     name = ds.make_immuta_table_name(
         handler_type=handler_type, schema=schema, table=table, user_prefix=user_prefix
     )
-    assert len(name) <= ds.MAX_IMMUTA_NAME_LIMIT
     assert (
-        name[: ds.MAX_IMMUTA_NAME_LIMIT - 8]
-        == expected_name[: ds.MAX_IMMUTA_NAME_LIMIT - 8]
+        name == expected_name
     )
 
 
@@ -148,8 +110,7 @@ def test_make_postgres_table_name(
     name = ds.make_postgres_table_name(
         handler_type=handler_type, schema=schema, table=table, user_prefix=user_prefix
     )
-    assert len(name) <= ds.MAX_POSTGRES_NAME_LIMIT
-    assert name == expected_name[: ds.MAX_POSTGRES_NAME_LIMIT]
+    assert name == expected_name
 
 
 MetadataTestKeys = namedtuple(
@@ -267,7 +228,7 @@ def test_to_immuta_objects(
     expected_type: Any,
     columns: List[ds.DataSourceColumn],
 ):
-    base_config = {"username": "foo", "password": "bar", "database": "baz", "disable_schema_evolution": "false"}
+    base_config = {"username": "foo", "password": "bar", "database": "baz", "disable_schema_evolution": "false", "owner_profile_id": 0}
     config = {**base_config, **db_keys}
     config["handler_type"] = handler_type
     source, handler, schema_evolution = ds.to_immuta_objects(
@@ -324,7 +285,7 @@ BULK_OBJECT_TESTS = [
 def test_make_bulk_create_objects(
     db_keys: Dict[str, str], handler_type: str, expected_type: Any, tables: List[str]
 ):
-    base_config = {"username": "foo", "password": "bar", "database": "baz", "disable_schema_evolution": "false"}
+    base_config = {"username": "foo", "password": "bar", "database": "baz", "disable_schema_evolution": "false", "owner_profile_id": 0}
     config = {**base_config, **db_keys}
     config["handler_type"] = handler_type
 

--- a/fh_immuta_utils/tests/test_data_source.py
+++ b/fh_immuta_utils/tests/test_data_source.py
@@ -125,6 +125,7 @@ POSTGRES_NAME_TESTS = [
     ),
 ]
 
+
 @pytest.mark.parametrize(
     "handler_type,schema,table,user_prefix,expected_name", IMMUTA_DATASOURCE_NAME_TESTS
 )
@@ -136,9 +137,10 @@ def test_make_immuta_datasource_name(
     )
     assert len(name) <= ds.MAX_IMMUTA_NAME_LIMIT
     assert (
-            name[: ds.MAX_IMMUTA_NAME_LIMIT - 8]
-            == expected_name[: ds.MAX_IMMUTA_NAME_LIMIT - 8]
+        name[: ds.MAX_IMMUTA_NAME_LIMIT - 8]
+        == expected_name[: ds.MAX_IMMUTA_NAME_LIMIT - 8]
     )
+
 
 @pytest.mark.parametrize(
     "handler_type,schema,table,user_prefix,expected_name", POSTGRES_NAME_TESTS

--- a/fh_immuta_utils/tests/test_data_source.py
+++ b/fh_immuta_utils/tests/test_data_source.py
@@ -267,10 +267,10 @@ def test_to_immuta_objects(
     expected_type: Any,
     columns: List[ds.DataSourceColumn],
 ):
-    base_config = {"username": "foo", "password": "bar", "database": "baz"}
+    base_config = {"username": "foo", "password": "bar", "database": "baz", "disable_schema_evolution": "false"}
     config = {**base_config, **db_keys}
     config["handler_type"] = handler_type
-    source, handler = ds.to_immuta_objects(
+    source, handler, schema_evolution = ds.to_immuta_objects(
         table="foo", schema="bar", config=config, columns=columns
     )
     assert source.name == ds.make_immuta_table_name(
@@ -324,11 +324,11 @@ BULK_OBJECT_TESTS = [
 def test_make_bulk_create_objects(
     db_keys: Dict[str, str], handler_type: str, expected_type: Any, tables: List[str]
 ):
-    base_config = {"username": "foo", "password": "bar", "database": "baz"}
+    base_config = {"username": "foo", "password": "bar", "database": "baz", "disable_schema_evolution": "false"}
     config = {**base_config, **db_keys}
     config["handler_type"] = handler_type
 
-    source, handlers = ds.make_bulk_create_objects(
+    source, handlers, schema_evolution = ds.make_bulk_create_objects(
         tables=tables, schema="bar", config=config
     )
     assert len(handlers) == len(tables)

--- a/fh_immuta_utils/tests/test_data_source.py
+++ b/fh_immuta_utils/tests/test_data_source.py
@@ -1,54 +1,18 @@
 from collections import namedtuple
 from typing import Dict, List, Any
-from pydantic import ValidationError
+from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 import fh_immuta_utils.data_source as ds
+from fh_immuta_utils.scripts.manage_data_sources import skip_dataset_enrollment
 
 NameTestKeys = namedtuple(
     "NameTestKeys", ["handler_type", "schema", "table", "user_prefix", "expected_name"]
 )
 
-IMMUTA_NAME_TESTS = [
-    NameTestKeys(
-        handler_type="PostgreSQL",
-        schema="foo",
-        table="barbazquxquux",
-        user_prefix="",
-        expected_name=f"{ds.PREFIX_MAP['PostgreSQL']}_foo_barbazquxquux",
-    ),
-    NameTestKeys(
-        handler_type="PostgreSQL",
-        schema="foo",
-        table="barbazquxquux",
-        user_prefix="quuz",
-        expected_name=f"quuz_{ds.PREFIX_MAP['PostgreSQL']}_foo_barbazquxquux",
-    ),
-    NameTestKeys(
-        handler_type="Redshift",
-        schema="foo",
-        table="barbazquxquux",
-        user_prefix="",
-        expected_name=f"{ds.PREFIX_MAP['Redshift']}_foo_barbazquxquux",
-    ),
-    NameTestKeys(
-        handler_type="Amazon S3",
-        schema="foo",
-        table="barbazquxquux",
-        user_prefix="",
-        expected_name=f"{ds.PREFIX_MAP['Amazon S3']}_foo_barbazquxquux",
-    ),
-    NameTestKeys(
-        handler_type="Amazon Athena",
-        schema="foo",
-        table="barbazquxquux",
-        user_prefix="",
-        expected_name=f"{ds.PREFIX_MAP['Amazon Athena']}_foo_barbazquxquux",
-    ),
-]
-
-POSTGRES_NAME_TESTS = [
+TABLE_NAME_TESTS = [
     NameTestKeys(
         handler_type="PostgreSQL",
         schema="foo",
@@ -88,29 +52,17 @@ POSTGRES_NAME_TESTS = [
 
 
 @pytest.mark.parametrize(
-    "handler_type,schema,table,user_prefix,expected_name", IMMUTA_NAME_TESTS
+    "handler_type,schema,table,user_prefix,expected_name", TABLE_NAME_TESTS
 )
-def test_make_immuta_table_name(
+def test_make_table_name(
     handler_type: str, schema: str, table: str, user_prefix: str, expected_name: str
 ):
-    name = ds.make_immuta_table_name(
+    name = ds.make_table_name(
         handler_type=handler_type, schema=schema, table=table, user_prefix=user_prefix
     )
     assert (
         name == expected_name
     )
-
-
-@pytest.mark.parametrize(
-    "handler_type,schema,table,user_prefix,expected_name", POSTGRES_NAME_TESTS
-)
-def test_make_postgres_table_name(
-    handler_type: str, schema: str, table: str, user_prefix: str, expected_name: str
-):
-    name = ds.make_postgres_table_name(
-        handler_type=handler_type, schema=schema, table=table, user_prefix=user_prefix
-    )
-    assert name == expected_name
 
 
 MetadataTestKeys = namedtuple(
@@ -228,21 +180,22 @@ def test_to_immuta_objects(
     expected_type: Any,
     columns: List[ds.DataSourceColumn],
 ):
-    base_config = {"username": "foo", "password": "bar", "database": "baz", "disable_schema_evolution": "false", "owner_profile_id": 0}
+    base_config = {"username": "foo", "password": "bar", "database": "baz", "owner_profile_id": 0}
     config = {**base_config, **db_keys}
     config["handler_type"] = handler_type
     source, handler, schema_evolution = ds.to_immuta_objects(
         table="foo", schema="bar", config=config, columns=columns
     )
-    assert source.name == ds.make_immuta_table_name(
+    assert source.name == ds.make_table_name(
         table="foo", schema="bar", handler_type=handler_type, user_prefix=""
     )
-    assert source.sqlTableName == ds.make_postgres_table_name(
+    assert source.sqlTableName == ds.make_table_name(
         table="foo", schema="bar", handler_type=handler_type, user_prefix=""
     )
     assert source.blobHandlerType == handler_type
     assert isinstance(handler, ds.Handler)
     assert isinstance(handler.metadata, expected_type)
+    assert isinstance(schema_evolution, ds.SchemaEvolutionMetadata)
 
 
 TABLES = ["foo", "bar", "baz"]
@@ -285,7 +238,7 @@ BULK_OBJECT_TESTS = [
 def test_make_bulk_create_objects(
     db_keys: Dict[str, str], handler_type: str, expected_type: Any, tables: List[str]
 ):
-    base_config = {"username": "foo", "password": "bar", "database": "baz", "disable_schema_evolution": "false", "owner_profile_id": 0}
+    base_config = {"username": "foo", "password": "bar", "database": "baz", "owner_profile_id": 0}
     config = {**base_config, **db_keys}
     config["handler_type"] = handler_type
 
@@ -303,8 +256,148 @@ def test_make_bulk_create_objects(
 
     for table in tables:
         assert (
-            ds.make_immuta_table_name(
+            ds.make_table_name(
                 table=table, schema="bar", handler_type=handler_type, user_prefix=""
             )
             in table_names
         )
+
+    assert isinstance(schema_evolution, ds.SchemaEvolutionMetadata)
+
+SCHEMA_EVOLUTION_METADATA_TESTS = {
+    "schema_evolution_no_config": (
+        {
+            "owner_profile_id": 0,
+            "handler_type": "Redshift",
+        },
+        ds.SchemaEvolutionMetadata(
+            ownerProfileId=0,
+            disabled=True,
+            config=ds.SchemaEvolutionMetadataConfig(
+                nameTemplate={
+                    "nameFormat": "rs_<schema>_<tablename>",
+                    "tableFormat": "rs_<schema>_<tablename>",
+                    "sqlSchemaNameFormat": "<schema>",
+                }
+            )
+        )
+    ),
+    "schema_evolution_no_config_change_handler": (
+        {
+            "owner_profile_id": 0,
+            "handler_type": "Amazon Athena",
+        },
+        ds.SchemaEvolutionMetadata(
+            ownerProfileId=0,
+            disabled=True,
+            config=ds.SchemaEvolutionMetadataConfig(
+                nameTemplate={
+                    "nameFormat": "ath_<schema>_<tablename>",
+                    "tableFormat": "ath_<schema>_<tablename>",
+                    "sqlSchemaNameFormat": "<schema>",
+                }
+            )
+        )
+    ),
+    "schema_evolution_disabled": (
+        {
+            "owner_profile_id": 0,
+            "handler_type": "Redshift",
+            "schema_evolution": {
+                "disable_schema_evolution": "true",
+                "immuta_name_format": "foo",
+                "sql_table_name_format": "bar",
+                "sql_schema_name_format": "biz",
+            }
+        },
+        ds.SchemaEvolutionMetadata(
+            ownerProfileId=0,
+            disabled=True,
+            config=ds.SchemaEvolutionMetadataConfig(
+                nameTemplate={
+                    "nameFormat": "foo",
+                    "tableFormat": "bar",
+                    "sqlSchemaNameFormat": "biz",
+                }
+            )
+        )
+    ),
+    "schema_evolution_enabled": (
+        {
+            "owner_profile_id": 0,
+            "handler_type": "Redshift",
+            "schema_evolution": {
+                "disable_schema_evolution": "false",
+                "immuta_name_format": "foo",
+                "sql_table_name_format": "bar",
+                "sql_schema_name_format": "biz",
+            }
+        },
+        ds.SchemaEvolutionMetadata(
+            ownerProfileId=0,
+            disabled=False,
+            config=ds.SchemaEvolutionMetadataConfig(
+                nameTemplate={
+                    "nameFormat": "foo",
+                    "tableFormat": "bar",
+                    "sqlSchemaNameFormat": "biz",
+                }
+            )
+        )
+    ),
+}
+
+
+@pytest.mark.parametrize("config, expected", list(SCHEMA_EVOLUTION_METADATA_TESTS.values()), ids=list(SCHEMA_EVOLUTION_METADATA_TESTS.keys()))
+def test_make_schema_evolution_metadata(config: Dict[str, Any], expected: ds.SchemaEvolutionMetadata):
+    assert isinstance(ds.make_schema_evolution_metadata(config), ds.SchemaEvolutionMetadata)
+    assert ds.make_schema_evolution_metadata(config) == expected
+
+
+SKIP_DATASET_ENROLLMENT_TESTS = {
+    "schema_evolution_enabled_config_enabled": (
+        {
+            "is_schema_evolution_enabled": True,
+            "schema_evolution": {
+                "disable_schema_evolution": False,
+            }
+        },
+        True
+    ),
+    "schema_evolution_enabled_config_disabled": (
+        {
+            "is_schema_evolution_enabled": True,
+            "schema_evolution": {
+                "disable_schema_evolution": True,
+            }
+        },
+        False
+    ),
+    "schema_evolution_disabled_config_disabled": (
+        {
+            "is_schema_evolution_enabled": False,
+            "schema_evolution": {
+                "disable_schema_evolution": True,
+            }
+        },
+        False
+    ),
+    "schema_evolution_disabled_config_enabled": (
+        {
+            "is_schema_evolution_enabled": False,
+            "schema_evolution": {
+                "disable_schema_evolution": False,
+            }
+        },
+        False
+    )
+}
+
+
+@pytest.mark.parametrize("config, expected", list(SKIP_DATASET_ENROLLMENT_TESTS.values()), ids=list(SKIP_DATASET_ENROLLMENT_TESTS.keys()))
+@patch("fh_immuta_utils.scripts.manage_data_sources.is_schema_evolution_enabled")
+def test_skip_dataset_enrollment(mock_is_schema_evolution_enabled, config, expected):
+    config["hostname"] = "redshift.foobar.io"
+    config["database"] = "data"
+    mock_is_schema_evolution_enabled.return_value = config["is_schema_evolution_enabled"]
+    assert skip_dataset_enrollment(None, config) == expected

--- a/fh_immuta_utils/tests/test_data_source.py
+++ b/fh_immuta_utils/tests/test_data_source.py
@@ -284,9 +284,9 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
             disabled=True,
             config=ds.SchemaEvolutionMetadataConfig(
                 nameTemplate={
-                    "nameFormat": "rs_<schema>_<tablename>",
-                    "tableFormat": "rs_<schema>_<tablename>",
-                    "sqlSchemaNameFormat": "<schema>",
+                    "dataSourceNameFormat": "rs_<schema>_<tablename>",
+                    "queryEngineTableNameFormat": "rs_<schema>_<tablename>",
+                    "queryEngineSchemaNameFormat": "<schema>",
                 }
             ),
         ),
@@ -301,9 +301,9 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
             disabled=True,
             config=ds.SchemaEvolutionMetadataConfig(
                 nameTemplate={
-                    "nameFormat": "ath_<schema>_<tablename>",
-                    "tableFormat": "ath_<schema>_<tablename>",
-                    "sqlSchemaNameFormat": "<schema>",
+                    "dataSourceNameFormat": "ath_<schema>_<tablename>",
+                    "queryEngineTableNameFormat": "ath_<schema>_<tablename>",
+                    "queryEngineSchemaNameFormat": "<schema>",
                 }
             ),
         ),
@@ -314,9 +314,9 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
             "handler_type": "Redshift",
             "schema_evolution": {
                 "disable_schema_evolution": "true",
-                "immuta_name_format": "foo",
-                "sql_table_name_format": "bar",
-                "sql_schema_name_format": "biz",
+                "datasource_name_format": "foo",
+                "query_engine_table_name_format": "bar",
+                "query_engine_schema_name_format": "biz",
             },
         },
         ds.SchemaEvolutionMetadata(
@@ -324,9 +324,9 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
             disabled=True,
             config=ds.SchemaEvolutionMetadataConfig(
                 nameTemplate={
-                    "nameFormat": "foo",
-                    "tableFormat": "bar",
-                    "sqlSchemaNameFormat": "biz",
+                    "dataSourceNameFormat": "foo",
+                    "queryEngineTableNameFormat": "bar",
+                    "queryEngineSchemaNameFormat": "biz",
                 }
             ),
         ),
@@ -337,9 +337,9 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
             "handler_type": "Redshift",
             "schema_evolution": {
                 "disable_schema_evolution": "false",
-                "immuta_name_format": "foo",
-                "sql_table_name_format": "bar",
-                "sql_schema_name_format": "biz",
+                "datasource_name_format": "foo",
+                "query_engine_table_name_format": "bar",
+                "query_engine_schema_name_format": "biz",
             },
         },
         ds.SchemaEvolutionMetadata(
@@ -347,9 +347,9 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
             disabled=False,
             config=ds.SchemaEvolutionMetadataConfig(
                 nameTemplate={
-                    "nameFormat": "foo",
-                    "tableFormat": "bar",
-                    "sqlSchemaNameFormat": "biz",
+                    "dataSourceNameFormat": "foo",
+                    "queryEngineTableNameFormat": "bar",
+                    "queryEngineSchemaNameFormat": "biz",
                 }
             ),
         ),

--- a/fh_immuta_utils/tests/test_policy.py
+++ b/fh_immuta_utils/tests/test_policy.py
@@ -214,4 +214,4 @@ def test_make_subscription_policy_action(subscription_policy_actions_dict, tagge
 
 
 def test_subscription_policy_staged(subscription_policy_staged_bool):
-    assert subscription_policy_staged_bool == False
+    assert subscription_policy_staged_bool is False

--- a/release_notes/@vNext.md
+++ b/release_notes/@vNext.md
@@ -1,1 +1,10 @@
-<!-- to be filled in -->
+# 0.4.0 (2020-03-01)
+
+## Compatible with Immuta version `>=2020.3.4`
+
+### Added
+- Ability to control schema evolution settings for a remote database/server from configuration.
+### Removed
+- Immuta data source and SQL table name truncation logic. SQL table name max length is now 255 characters in the Query
+  Engine, and the Immuta data source name max length is at least 255 characters. Users with previously truncated data
+  source or SQL table names should delete and re-enroll those data sources to enroll the full names.

--- a/release_notes/@vNext.md
+++ b/release_notes/@vNext.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Ability to control schema evolution settings for a remote database/server from configuration.
-### Removed
-- Immuta data source and SQL table name truncation logic. SQL table name max length is now 255 characters in the Query
-  Engine, and the Immuta data source name max length is at least 255 characters. Users with previously truncated data
-  source or SQL table names should delete and re-enroll those data sources to enroll the full names.
+### Changed
+- Immuta data source and query engine table name truncation character limits. Limits for both are now set to 255 to
+  align with the accepted limits by the Immuta application. Users with previously truncated data source or query engine
+  table names should delete and re-enroll those data sources to enroll the full names.


### PR DESCRIPTION
Major changes include:

- Allowing the enabling and disabling of schema monitoring for an entire remote database 
- Adding business logic to skip dataset enrollment if it's already enrolled with schema monitoring enabled 
- Removing outdated truncation logic for Immuta data source and SQL table names to align with increased limits on the Immuta side (now 255 chars)

See doc updates for more information. Tested on 2020.3.4.