### PR TITLE
Align data source enrollment with Immuta defaults and fix tagging

### DIFF
--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -41,7 +41,7 @@ Note the following:
 
 * Enabling or disabling schema evolution requires a schema value is present in the `schemas_to_bulk_enroll` key in the
   configuration. **When enabling schema evolution for the first time for a remote database**, a bulk enroll of a
-  non-enrolled schema must be run to correctly create the schema evolution record in Immuta
+  non-enrolled schema must be run to correctly create the schema evolution record in Immuta.
 * Data sources enrolled with schema evolution automatically have table evolution enabled. See the internal Immuta
   documentation page titled "Schema Monitoring" for more information on table evolution.
 * Schemas and tables are enrolled with the currently authenticated user running `fh-immuta-utils` as the owner
@@ -66,7 +66,7 @@ An example of a state file for a PostgreSQL database is as follows:
 hostname: my-database.foo.com
 port: 5439
 database: db-name
-# Prefix to prepend to name of data source created in Immuta
+# Prefix to add to data source names and query engine table names created in Immuta
 user_prefix:
 handler_type: PostgreSQL
 # List of schemas to enroll where for each schema,
@@ -78,6 +78,9 @@ schemas_to_enroll:
 # List of schemas where we want to enroll all tables in each schema
 schemas_to_bulk_enroll:
   - schema_prefix: "baz"
+    query_engine_target_schema: "foobar"  # Override target schema name in the Query Engine. Defaults to original schema
+    prefix_names_with_handler: true  # Prefix handler to data source and query engine table names. Defaults to false
+    prefix_names_with_schema: true  # Prefix schema name to data source and query engine table names. Defaults to false
 # Schema evolution enablement and naming templates
 schema_evolution:
   disable_schema_evolution: true
@@ -90,7 +93,7 @@ credentials:
   key: USER_PASSWORD
   username: service_user
 # Tags to apply directly to data sources created by this config file.
-# Key follows the pattern <prefix>_<schema>, where prefix matches with PREFIX_MAP in data_source.py
+# Keys will match on data source names using Unix shell-style wildcard matching and apply the tags
 tags:
   pg_baz: ["tag1", "tag2.subtag2"]
   pg_foo: ["tag3", "tag4"]
@@ -108,7 +111,7 @@ An example of a state file for an AWS Athena database is as follows:
 region: us-east-1
 hostname: us-east-1
 database: my-database
-# Prefix to prepend to name of data source created in Immuta
+# Prefix to add to data source names and query engine table names created in Immuta
 user_prefix:
 handler_type: Amazon Athena
 queryResultLocationBucket: bucket-where-results-should-be-stored
@@ -119,6 +122,9 @@ schemas_to_enroll:
   # Will glob in database for all schemas starting with this prefix.
   - schema_prefix: foo
     table_prefix: bar
+    query_engine_target_schema: "foobar"  # Override target schema name in the Query Engine. Defaults to original schema
+    prefix_names_with_handler: false  # Prefix handler to data source and query engine table names. Defaults to false
+    prefix_names_with_schema: false  # Prefix schema name to data source and query engine table names. Defaults to false
 # List of schemas where we want to enroll all tables in each schema
 schemas_to_bulk_enroll:
 # Schema evolution enablement and naming templates
@@ -132,7 +138,7 @@ credentials:
   source: VAULT
   key: path/to/vault/secret
 # Tags to apply directly to data sources created by this config file.
-# Key follows the pattern <prefix>_<schema>, where prefix matches with PREFIX_MAP in data_source.py
+# Keys will match on data source names using Unix shell-style wildcard matching and apply the tags
 tags:
   ath_foo: ["tag1", "tag2.subtag2"]
 ```

--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -79,13 +79,13 @@ schemas_to_enroll:
 schemas_to_bulk_enroll:
   - schema_prefix: "baz"
     query_engine_target_schema: "foobar"  # Override target schema name in the Query Engine. Defaults to original schema
-    prefix_names_with_handler: true  # Prefix handler to data source and query engine table names. Defaults to false
-    prefix_names_with_schema: true  # Prefix schema name to data source and query engine table names. Defaults to false
-# Schema evolution enablement and naming templates
+    prefix_query_engine_names_with_handler: false  # Prefix handler to query engine table names. Defaults to false
+    prefix_query_engine_names_with_schema: false  # Prefix schema to query engine table names. Defaults to false
+# Schema evolution enablement and naming templates (defaults shown below)
 schema_evolution:
   disable_schema_evolution: true
   datasource_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
-  query_engine_table_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  query_engine_table_name_format: "<user_prefix>_<tablename>"
   query_engine_schema_name_format: "<schema>"
 credentials:
   # Read from environment variable
@@ -95,8 +95,8 @@ credentials:
 # Tags to apply directly to data sources created by this config file.
 # Keys will match on data source names using Unix shell-style wildcard matching and apply the tags
 tags:
-  pg_baz: ["tag1", "tag2.subtag2"]
-  pg_foo: ["tag3", "tag4"]
+  "pg_baz*": ["tag1", "tag2.subtag2"]
+  "pg_foo*": ["tag3", "tag4"]
 ```
 
 **Note:** For AWS Redshift, use the same format as above, replacing the `handler_type` value with `Redshift`.
@@ -123,15 +123,15 @@ schemas_to_enroll:
   - schema_prefix: foo
     table_prefix: bar
     query_engine_target_schema: "foobar"  # Override target schema name in the Query Engine. Defaults to original schema
-    prefix_names_with_handler: false  # Prefix handler to data source and query engine table names. Defaults to false
-    prefix_names_with_schema: false  # Prefix schema name to data source and query engine table names. Defaults to false
+    prefix_query_engine_names_with_handler: false  # Prefix handler to query engine table names. Defaults to false
+    prefix_query_engine_names_with_schema: false  # Prefix schema to query engine table names. Defaults to false
 # List of schemas where we want to enroll all tables in each schema
 schemas_to_bulk_enroll:
-# Schema evolution enablement and naming templates
+# Schema evolution enablement and naming templates (defaults shown below)
 schema_evolution:
   disable_schema_evolution: true
   datasource_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
-  query_engine_table_name_format: "<user_prefix>_<handler_prefix>_<schema>_<tablename>"
+  query_engine_table_name_format: "<user_prefix>_<tablename>"
   query_engine_schema_name_format: "<schema>"
 credentials:
   # Read from an instance of Hashicorp Vault
@@ -140,7 +140,7 @@ credentials:
 # Tags to apply directly to data sources created by this config file.
 # Keys will match on data source names using Unix shell-style wildcard matching and apply the tags
 tags:
-  ath_foo: ["tag1", "tag2.subtag2"]
+  "ath_foo*": ["tag1", "tag2.subtag2"]
 ```
 
 ## Data Source Column Tags

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -218,8 +218,8 @@ def make_bulk_create_objects(
     tables: List[str],
     user_prefix: Optional[str] = None,
     bodata_schema_name: str = "",
-    prefix_names_with_schema: bool = True,
-    prefix_names_with_handler: bool = True,
+    prefix_names_with_schema: bool = False,
+    prefix_names_with_handler: bool = False,
 ) -> Tuple[DataSource, List[Handler], SchemaEvolutionMetadata]:
     """
     Returns a (data source, metadata) tuple containing relevant details to bulk create new data

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -343,21 +343,16 @@ def make_handler_metadata(
 
 def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMetadata:
     """
-    Builds metadata for the schema evolution object. Immuta table name and SQL table name template defaults match the
-    pattern defined in make_table_name()
+    Builds metadata for the schema evolution object. Immuta data source name and Query Engine table name template
+    defaults match the patterns set in the Immuta UI.
     :param config: dataset configuration dictionary
     :return: SchemaEvolutionMetadata object
     """
     user_prefix = ""
-    if config.get("prefix"):
-        user_prefix = f"{config.get('prefix')}_"
-    handler_prefix = PREFIX_MAP[config["handler_type"]]
-    datasource_name_format_default = (
-        f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
-    )
-    query_engine_table_name_format_default = (
-        f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
-    )
+    if config.get("user_prefix"):
+        user_prefix = f"{config.get('user_prefix')}_"
+    datasource_name_format_default = f"{user_prefix}<tablename>"
+    query_engine_table_name_format_default = f"{user_prefix}<tablename>"
     query_engine_schema_name_format_default = "<schema>"
 
     return SchemaEvolutionMetadata(
@@ -368,7 +363,8 @@ def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMet
         config=SchemaEvolutionMetadataConfig(
             nameTemplate=SchemaEvolutionMetadataConfigTemplate(
                 dataSourceNameFormat=config.get("schema_evolution", {}).get(
-                    "datasource_name_format", datasource_name_format_default
+                    "datasource_name_format",
+                    datasource_name_format_default,
                 ),
                 queryEngineTableNameFormat=config.get("schema_evolution", {}).get(
                     "query_engine_table_name_format",

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -163,8 +163,10 @@ class HandlerMetadata(BaseModel):
     staleDataTolerance: int
     # Don't know what this is. . .
     # blobId: List[str]
-    # Table name that is exposed by Immuta
+    # Table name that is exposed by the Query Engine
     bodataTableName: str = ""
+    # Schema name for the table in the Query Engine
+    bodataSchemaName: str = ""
     # The name of the Data Source to which this handler corresponds
     dataSourceName: str = ""
     columns: Optional[List[DataSourceColumn]] = None
@@ -213,6 +215,7 @@ def make_bulk_create_objects(
     schema: str,
     tables: List[str],
     user_prefix: Optional[str] = None,
+    bodata_schema_name: str = "",
 ) -> Tuple[DataSource, List[Handler], SchemaEvolutionMetadata]:
     """
     Returns a (data source, metadata) tuple containing relevant details to bulk create new data
@@ -237,6 +240,7 @@ def make_bulk_create_objects(
             schema=schema,
             config=config,
             bodataTableName=postgres_table_name,
+            bodataSchemaName=bodata_schema_name,
             dataSourceName=immuta_datasource_name,
         )
         handlers.append(handler)
@@ -255,6 +259,7 @@ def to_immuta_objects(
     table: str,
     columns: List[DataSourceColumn],
     user_prefix: Optional[str] = None,
+    bodata_schema_name: str = "",
 ) -> Tuple[DataSource, Handler, SchemaEvolutionMetadata]:
     """
     Returns a tuple containing relevant details to create a new data source
@@ -278,6 +283,7 @@ def to_immuta_objects(
         config=config,
         columns=columns,
         bodataTableName=postgres_table_name,
+        bodataSchemaName=bodata_schema_name,
         dataSourceName=immuta_datasource_name,
     )
     ds = DataSource(

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -54,11 +54,8 @@ def make_immuta_datasource_name(
     """
     table_name = ""
     table_name += f"{user_prefix}_" if user_prefix else ""
-    table_name += f"{PREFIX_MAP[handler_type]}_" if handler_type else ""
-    table_name += f"{schema}_" if schema else ""
-    table_name += f"{table}"
-    if not table_name:
-        return ""
+    table_name += f"{PREFIX_MAP[handler_type]}_{schema}_{table}"
+
     if len(table_name) <= MAX_IMMUTA_NAME_LIMIT:
         return table_name
     import hashlib

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -218,8 +218,8 @@ def make_bulk_create_objects(
     tables: List[str],
     user_prefix: Optional[str] = None,
     bodata_schema_name: str = "",
-    prefix_names_with_schema: bool = False,
-    prefix_names_with_handler: bool = False,
+    prefix_query_engine_names_with_schema: bool = False,
+    prefix_query_engine_names_with_handler: bool = False,
 ) -> Tuple[DataSource, List[Handler], SchemaEvolutionMetadata]:
     """
     Returns a (data source, metadata) tuple containing relevant details to bulk create new data
@@ -228,14 +228,14 @@ def make_bulk_create_objects(
     handlers = []
     for table in tables:
         postgres_table_name = make_postgres_table_name(
-            handler_type=config["handler_type"] if prefix_names_with_handler else "",
-            schema=schema if prefix_names_with_schema else "",
+            handler_type=config["handler_type"] if prefix_query_engine_names_with_handler else "",
+            schema=schema if prefix_query_engine_names_with_schema else "",
             table=table,
             user_prefix=user_prefix,
         )
         immuta_datasource_name = make_immuta_datasource_name(
-            handler_type=config["handler_type"] if prefix_names_with_handler else "",
-            schema=schema if prefix_names_with_schema else "",
+            handler_type=config["handler_type"],
+            schema=schema,
             table=table,
             user_prefix=user_prefix,
         )
@@ -264,22 +264,22 @@ def to_immuta_objects(
     columns: List[DataSourceColumn],
     user_prefix: Optional[str] = None,
     bodata_schema_name: str = "",
-    prefix_names_with_schema: bool = True,
-    prefix_names_with_handler: bool = True,
+    prefix_query_engine_names_with_schema: bool = True,
+    prefix_query_engine_names_with_handler: bool = True,
 ) -> Tuple[DataSource, Handler, SchemaEvolutionMetadata]:
     """
     Returns a tuple containing relevant details to create a new data source
     in Immuta from the source schema
     """
     postgres_table_name = make_postgres_table_name(
-        handler_type=config["handler_type"] if prefix_names_with_handler else "",
-        schema=schema if prefix_names_with_schema else "",
+        handler_type=config["handler_type"] if prefix_query_engine_names_with_handler else "",
+        schema=schema if prefix_query_engine_names_with_schema else "",
         table=table,
         user_prefix=user_prefix,
     )
     immuta_datasource_name = make_immuta_datasource_name(
-        handler_type=config["handler_type"] if prefix_names_with_handler else "",
-        schema=schema if prefix_names_with_schema else "",
+        handler_type=config["handler_type"],
+        schema=schema,
         table=table,
         user_prefix=user_prefix,
     )
@@ -351,7 +351,8 @@ def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMet
     user_prefix = ""
     if config.get("user_prefix"):
         user_prefix = f"{config.get('user_prefix')}_"
-    datasource_name_format_default = f"{user_prefix}<tablename>"
+    handler_prefix = PREFIX_MAP[config["handler_type"]]
+    datasource_name_format_default = f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
     query_engine_table_name_format_default = f"{user_prefix}<tablename>"
     query_engine_schema_name_format_default = "<schema>"
 

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List, Tuple
+from typing import Dict, Any, Optional, List, Tuple, Union
 import logging
 
 from pydantic import BaseModel, Field
@@ -58,7 +58,7 @@ def make_immuta_datasource_name(
     table_name += f"{schema}_" if schema else ""
     table_name += f"{table}"
     if not table_name:
-        return None
+        return ""
     if len(table_name) <= MAX_IMMUTA_NAME_LIMIT:
         return table_name
     import hashlib
@@ -218,8 +218,8 @@ def make_bulk_create_objects(
     tables: List[str],
     user_prefix: Optional[str] = None,
     bodata_schema_name: str = "",
-    prefix_query_engine_names_with_schema: bool = False,
-    prefix_query_engine_names_with_handler: bool = False,
+    prefix_query_engine_names_with_schema: Union[str, bool] = False,
+    prefix_query_engine_names_with_handler: Union[str, bool] = False,
 ) -> Tuple[DataSource, List[Handler], SchemaEvolutionMetadata]:
     """
     Returns a (data source, metadata) tuple containing relevant details to bulk create new data
@@ -228,7 +228,9 @@ def make_bulk_create_objects(
     handlers = []
     for table in tables:
         postgres_table_name = make_postgres_table_name(
-            handler_type=config["handler_type"] if prefix_query_engine_names_with_handler else "",
+            handler_type=config["handler_type"]
+            if prefix_query_engine_names_with_handler
+            else "",
             schema=schema if prefix_query_engine_names_with_schema else "",
             table=table,
             user_prefix=user_prefix,
@@ -264,15 +266,17 @@ def to_immuta_objects(
     columns: List[DataSourceColumn],
     user_prefix: Optional[str] = None,
     bodata_schema_name: str = "",
-    prefix_query_engine_names_with_schema: bool = True,
-    prefix_query_engine_names_with_handler: bool = True,
+    prefix_query_engine_names_with_schema: Union[str, bool] = False,
+    prefix_query_engine_names_with_handler: Union[str, bool] = False,
 ) -> Tuple[DataSource, Handler, SchemaEvolutionMetadata]:
     """
     Returns a tuple containing relevant details to create a new data source
     in Immuta from the source schema
     """
     postgres_table_name = make_postgres_table_name(
-        handler_type=config["handler_type"] if prefix_query_engine_names_with_handler else "",
+        handler_type=config["handler_type"]
+        if prefix_query_engine_names_with_handler
+        else "",
         schema=schema if prefix_query_engine_names_with_schema else "",
         table=table,
         user_prefix=user_prefix,
@@ -352,7 +356,9 @@ def make_schema_evolution_metadata(config: Dict[str, Any]) -> SchemaEvolutionMet
     if config.get("user_prefix"):
         user_prefix = f"{config.get('user_prefix')}_"
     handler_prefix = PREFIX_MAP[config["handler_type"]]
-    datasource_name_format_default = f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
+    datasource_name_format_default = (
+        f"{user_prefix}{handler_prefix}_<schema>_<tablename>"
+    )
     query_engine_table_name_format_default = f"{user_prefix}<tablename>"
     query_engine_schema_name_format_default = "<schema>"
 

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -157,14 +157,19 @@ def data_sources_enroll_iterator(
                 continue
             LOGGER.info("Processing table: %s.%s", schema, table["tableName"])
             handler = make_handler_metadata(
-                config=config, table=table["tableName"], schema=schema
+                config=config,
+                table=table["tableName"],
+                schema=schema,
             )
             columns = client.get_column_types(
                 config=config, data_source_type=config["handler_type"], handler=handler
             )
-
             data_source, handler, schema_evolution = to_immuta_objects(
-                schema=schema, table=table["tableName"], columns=columns, config=config
+                schema=schema,
+                table=table["tableName"],
+                columns=columns,
+                config=config,
+                bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
             )
             yield data_source, handler, schema_evolution
 
@@ -190,6 +195,7 @@ def data_sources_bulk_enroll_iterator(
             tables=[table["tableName"] for table in tables],
             config=config,
             user_prefix=config.get("user_prefix"),
+            bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
         )
         yield data_source, handlers, schema_evolution
 

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -170,8 +170,8 @@ def data_sources_enroll_iterator(
                 columns=columns,
                 config=config,
                 bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
-                prefix_names_with_schema=schema_obj.get("prefix_names_with_schema", True),
-                prefix_names_with_handler=schema_obj.get("prefix_names_with_handler", True),
+                prefix_names_with_schema=schema_obj.get("prefix_names_with_schema", False),
+                prefix_names_with_handler=schema_obj.get("prefix_names_with_handler", False),
             )
             yield data_source, handler, schema_evolution
 
@@ -198,8 +198,8 @@ def data_sources_bulk_enroll_iterator(
             config=config,
             user_prefix=config.get("user_prefix"),
             bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
-            prefix_names_with_schema=schema_obj.get("prefix_names_with_schema", True),
-            prefix_names_with_handler=schema_obj.get("prefix_names_with_handler", True),
+            prefix_names_with_schema=schema_obj.get("prefix_names_with_schema", False),
+            prefix_names_with_handler=schema_obj.get("prefix_names_with_handler", False),
         )
         yield data_source, handlers, schema_evolution
 

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -170,8 +170,12 @@ def data_sources_enroll_iterator(
                 columns=columns,
                 config=config,
                 bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
-                prefix_query_engine_names_with_schema=schema_obj.get("prefix_query_engine_names_with_schema", False),
-                prefix_query_engine_names_with_handler=schema_obj.get("prefix_query_engine_names_with_handler", False),
+                prefix_query_engine_names_with_schema=schema_obj.get(
+                    "prefix_query_engine_names_with_schema", False
+                ),
+                prefix_query_engine_names_with_handler=schema_obj.get(
+                    "prefix_query_engine_names_with_handler", False
+                ),
             )
             yield data_source, handler, schema_evolution
 
@@ -198,8 +202,12 @@ def data_sources_bulk_enroll_iterator(
             config=config,
             user_prefix=config.get("user_prefix"),
             bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
-            prefix_query_engine_names_with_schema=schema_obj.get("prefix_query_engine_names_with_schema", False),
-            prefix_query_engine_names_with_handler=schema_obj.get("prefix_query_engine_names_with_handler", False),
+            prefix_query_engine_names_with_schema=schema_obj.get(
+                "prefix_query_engine_names_with_schema", False
+            ),
+            prefix_query_engine_names_with_handler=schema_obj.get(
+                "prefix_query_engine_names_with_handler", False
+            ),
         )
         yield data_source, handlers, schema_evolution
 

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -170,6 +170,8 @@ def data_sources_enroll_iterator(
                 columns=columns,
                 config=config,
                 bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
+                prefix_names_with_schema=schema_obj.get("prefix_names_with_schema", True),
+                prefix_names_with_handler=schema_obj.get("prefix_names_with_handler", True),
             )
             yield data_source, handler, schema_evolution
 
@@ -196,6 +198,8 @@ def data_sources_bulk_enroll_iterator(
             config=config,
             user_prefix=config.get("user_prefix"),
             bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
+            prefix_names_with_schema=schema_obj.get("prefix_names_with_schema", True),
+            prefix_names_with_handler=schema_obj.get("prefix_names_with_handler", True),
         )
         yield data_source, handlers, schema_evolution
 

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -170,8 +170,8 @@ def data_sources_enroll_iterator(
                 columns=columns,
                 config=config,
                 bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
-                prefix_names_with_schema=schema_obj.get("prefix_names_with_schema", False),
-                prefix_names_with_handler=schema_obj.get("prefix_names_with_handler", False),
+                prefix_query_engine_names_with_schema=schema_obj.get("prefix_query_engine_names_with_schema", False),
+                prefix_query_engine_names_with_handler=schema_obj.get("prefix_query_engine_names_with_handler", False),
             )
             yield data_source, handler, schema_evolution
 
@@ -198,8 +198,8 @@ def data_sources_bulk_enroll_iterator(
             config=config,
             user_prefix=config.get("user_prefix"),
             bodata_schema_name=schema_obj.get("query_engine_target_schema", schema),
-            prefix_names_with_schema=schema_obj.get("prefix_names_with_schema", False),
-            prefix_names_with_handler=schema_obj.get("prefix_names_with_handler", False),
+            prefix_query_engine_names_with_schema=schema_obj.get("prefix_query_engine_names_with_schema", False),
+            prefix_query_engine_names_with_handler=schema_obj.get("prefix_query_engine_names_with_handler", False),
         )
         yield data_source, handlers, schema_evolution
 

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -53,7 +53,8 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
     with Paginator(client.get_data_source_list, search_text=search_text) as paginator:
         for data_source in paginator:
             data_sources_to_tag.append(
-                {"id": data_source["id"], "name": data_source["name"]}
+                {"id": data_source["id"], "name": data_source["name"], "handler_type": data_source["blobHandlerType"],
+                 "connection_string": data_source["connectionString"]}
             )
 
     progress_iterator = tqdm(data_sources_to_tag)
@@ -61,7 +62,7 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
         progress_iterator.set_description(
             desc=f"Tagging ID: {data_source['id']}, Name: {data_source['name']} :"
         )
-        data_source_tags = tagger.get_tags_for_data_source(name=data_source["name"])
+        data_source_tags = tagger.get_tags_for_data_source(data_source=data_source)
         if data_source_tags:
             logging.debug(f"Adding data source tags to {data_source['name']}.")
             if not dry_run:

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -62,7 +62,11 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
         progress_iterator.set_description(
             desc=f"Tagging ID: {data_source['id']}, Name: {data_source['name']} :"
         )
-        data_source_tags = tagger.get_tags_for_data_source(data_source=data_source)
+        data_source_tags = tagger.get_tags_for_data_source(
+            name=data_source['name'],
+            handler_type=data_source['handler_type'],
+            connection_string=data_source['connection_string'],
+        )
         if data_source_tags:
             logging.debug(f"Adding data source tags to {data_source['name']}.")
             if not dry_run:

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -68,7 +68,7 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
             connection_string=data_source['connection_string'],
         )
         if data_source_tags:
-            logging.debug(f"Adding data source tags to {data_source['name']}.")
+            logging.debug(f"\nAdding data source-level tags to {data_source['name']}.")
             if not dry_run:
                 client.tag_data_source(id=data_source["id"], tag_data=data_source_tags)
         dictionary = client.get_data_source_dictionary(id=data_source["id"])

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -53,8 +53,12 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
     with Paginator(client.get_data_source_list, search_text=search_text) as paginator:
         for data_source in paginator:
             data_sources_to_tag.append(
-                {"id": data_source["id"], "name": data_source["name"], "handler_type": data_source["blobHandlerType"],
-                 "connection_string": data_source["connectionString"]}
+                {
+                    "id": data_source["id"],
+                    "name": data_source["name"],
+                    "handler_type": data_source["blobHandlerType"],
+                    "connection_string": data_source["connectionString"],
+                }
             )
 
     progress_iterator = tqdm(data_sources_to_tag)
@@ -63,9 +67,9 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
             desc=f"Tagging ID: {data_source['id']}, Name: {data_source['name']} :"
         )
         data_source_tags = tagger.get_tags_for_data_source(
-            name=data_source['name'],
-            handler_type=data_source['handler_type'],
-            connection_string=data_source['connection_string'],
+            name=data_source["name"],
+            handler_type=data_source["handler_type"],
+            connection_string=data_source["connection_string"],
         )
         if data_source_tags:
             logging.debug(f"\nAdding data source-level tags to {data_source['name']}.")

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -63,10 +63,12 @@ class Tagger(object):
     def get_tags_for_column(self, column_name: str) -> List[str]:
         return self.tag_map_datadict.get(column_name, [])
 
-    def get_tags_for_data_source(self, name: str, handler_type: str, connection_string: str) -> List[Dict[str, Any]]:
+    def get_tags_for_data_source(
+        self, name: str, handler_type: str, connection_string: str
+    ) -> List[Dict[str, Any]]:
         """
-        Finds tags whose prefix key matches the prefix of the data source name.
-        e.g. if prefix key is "ath_foo", all data source names with prefix "ath_foo" will get that prefix key's tags
+        Finds tags whose key matches a data source name using Unix shell-style wildcard matching.
+        e.g. if key is "ath_foo*", all data source names with prefix "ath_foo" will get that key's tags
         :param name: the data source name
         :param handler_type: the type of handler for this data source (e.g. Redshift, Amazon Athena, etc.)
         :param connection_string: the remote database connection string for the data source
@@ -74,7 +76,7 @@ class Tagger(object):
         """
         tags_for_data_source = []
         # remote database is not returned by the API so we strip it from the connection string
-        database = connection_string[connection_string.rfind("/")+1:]
+        database = connection_string[connection_string.rfind("/") + 1 :]
         tag_dict = self.tag_map_datasource.get((handler_type, database), {})
 
         for prefix, tag_list in tag_dict.items():
@@ -87,7 +89,10 @@ class Tagger(object):
         """
         Determines if tag is the true root by checking all available tags from config
         """
-        all_tags = {**self.tag_map_datadict, **self.tag_map_datasource}
+        tag_map_datasource_dicts: Dict[str, List[str]] = {}
+        for tag_dict in self.tag_map_datasource.values():
+            tag_map_datasource_dicts = {**tag_map_datasource_dicts, **tag_dict}
+        all_tags = {**self.tag_map_datadict, **tag_map_datasource_dicts}
         tag_list = []
         for k, v in all_tags.items():
             tag_list.append(v)

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -1,12 +1,15 @@
+import fnmatch
 from collections import defaultdict
 import logging
 import os
 import glob
+from functools import partial
 from typing import Any, Dict, List, Iterator, Tuple, TYPE_CHECKING
 
 import yaml
 
 from pydantic import BaseModel
+from toolz.dicttoolz import keyfilter
 
 from .data_source import DataSourceColumn
 
@@ -28,8 +31,8 @@ class Tagger(object):
         # column_name: [tag1, tag2, ...]
         self.tag_map_datadict: Dict[str, List[str]] = {}
 
-        # prefix_schema: [tag1, tag2, ...]
-        self.tag_map_datasource: Dict[str, List[str]] = {}
+        # (handler_type, database): {"prefix": [tag1, tag2, ..]}
+        self.tag_map_datasource: Dict[Tuple, Dict[str, List[str]]] = {}
 
         self.read_configs(config_root=config_root)
 
@@ -49,27 +52,36 @@ class Tagger(object):
             logging.debug("Reading enrolled data source file: %s", datasource_file)
             with open(datasource_file) as handle:
                 contents = yaml.safe_load(handle)
+                handler_type = contents.get("handler_type")
+                database = contents.get("database")
+                tag_map_entry = {(handler_type, database): contents.get("tags", {})}
                 self.tag_map_datasource = {
                     **self.tag_map_datasource,
-                    **contents.get("tags", {}),
+                    **tag_map_entry,
                 }
 
     def get_tags_for_column(self, column_name: str) -> List[str]:
         return self.tag_map_datadict.get(column_name, [])
 
-    def get_tags_for_data_source(self, name: str) -> List[Dict[str, Any]]:
+    def get_tags_for_data_source(self, data_source: Any) -> List[Dict[str, Any]]:
         """
-        Finds tags whose key matches the prefix of the data source name.
-        e.g. if key is "ath_foo", all data sources with prefix "ath_foo" will get that key's tags
-        :param name: data source name
+        Finds tags whose prefix key matches the prefix of the data source name.
+        e.g. if prefix key is "ath_foo", all data source names with prefix "ath_foo" will get that prefix key's tags
+        :param data_source: data source object
         :return: list of tag dicts
         """
-        tags = []
-        for k, v in self.tag_map_datasource.items():
-            if name.startswith(k):
-                for tag in v:
-                    tags.append({"name": tag, "source": "curated"})
-        return tags
+        tags_for_data_source = []
+        handler_type = data_source["handler_type"]
+        conn_string = data_source["connection_string"]
+        # remote database is not returned by the API so we strip it from the connection string
+        database = conn_string[conn_string.rfind("/")+1:]
+        tag_dict = self.tag_map_datasource.get((handler_type, database), {})
+
+        for prefix, tag_list in tag_dict.items():
+            if fnmatch.fnmatch(data_source["name"], prefix):
+                for tag in tag_list:
+                    tags_for_data_source.append({"name": tag, "source": "curated"})
+        return tags_for_data_source
 
     def is_root_tag(self, tag_to_check: str) -> bool:
         """
@@ -94,12 +106,19 @@ class Tagger(object):
         """
 
         all_tags: Dict[str, List[str]] = defaultdict(list)
-        datasource_datadict_tags = {**self.tag_map_datadict, **self.tag_map_datasource}
-        for tag_list in datasource_datadict_tags.values():
+        for tag_list in self.tag_map_datadict.values():
             for tag in tag_list:
                 parent = tag.split(".")[0]
                 if tag not in all_tags[parent]:
                     all_tags[parent].append(tag)
+
+        for tag_dict in self.tag_map_datasource.values():
+            for tag_list in tag_dict.values():
+                for tag in tag_list:
+                    parent = tag.split(".")[0]
+                    if tag not in all_tags[parent]:
+                        all_tags[parent].append(tag)
+
         for root_tag, children in all_tags.items():
             if len(children) == 1 and children[0] == root_tag:
                 children = []

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -63,22 +63,22 @@ class Tagger(object):
     def get_tags_for_column(self, column_name: str) -> List[str]:
         return self.tag_map_datadict.get(column_name, [])
 
-    def get_tags_for_data_source(self, data_source: Any) -> List[Dict[str, Any]]:
+    def get_tags_for_data_source(self, name: str, handler_type: str, connection_string: str) -> List[Dict[str, Any]]:
         """
         Finds tags whose prefix key matches the prefix of the data source name.
         e.g. if prefix key is "ath_foo", all data source names with prefix "ath_foo" will get that prefix key's tags
-        :param data_source: data source object
+        :param name: the data source name
+        :param handler_type: the type of handler for this data source (e.g. Redshift, Amazon Athena, etc.)
+        :param connection_string: the remote database connection string for the data source
         :return: list of tag dicts
         """
         tags_for_data_source = []
-        handler_type = data_source["handler_type"]
-        conn_string = data_source["connection_string"]
         # remote database is not returned by the API so we strip it from the connection string
-        database = conn_string[conn_string.rfind("/")+1:]
+        database = connection_string[connection_string.rfind("/")+1:]
         tag_dict = self.tag_map_datasource.get((handler_type, database), {})
 
         for prefix, tag_list in tag_dict.items():
-            if fnmatch.fnmatch(data_source["name"], prefix):
+            if fnmatch.fnmatch(name, prefix):
                 for tag in tag_list:
                     tags_for_data_source.append({"name": tag, "source": "curated"})
         return tags_for_data_source

--- a/fh_immuta_utils/tests/test_data_source.py
+++ b/fh_immuta_utils/tests/test_data_source.py
@@ -21,20 +21,6 @@ IMMUTA_DATASOURCE_NAME_TESTS = [
         expected_name=f"{ds.PREFIX_MAP['PostgreSQL']}_foo_barbazquxquux",
     ),
     NameTestKeys(
-        handler_type="",
-        schema="foo",
-        table="barbazquxquux",
-        user_prefix="",
-        expected_name="foo_barbazquxquux",
-    ),
-    NameTestKeys(
-        handler_type="PostgreSQL",
-        schema="",
-        table="barbazquxquux",
-        user_prefix="",
-        expected_name=f"{ds.PREFIX_MAP['PostgreSQL']}_barbazquxquux",
-    ),
-    NameTestKeys(
         handler_type="PostgreSQL",
         schema="foo",
         table="barbazquxquux",
@@ -526,7 +512,7 @@ def test_make_bulk_create_objects(
 
     table_names = []
     for handler in handlers:
-        table_names.append(handler.metadata.bodataTableName)
+        table_names.append(handler.metadata.dataSourceName)
         assert handler.metadata.bodataSchemaName == query_engine_target_schema
         assert isinstance(handler, ds.Handler)
         assert isinstance(handler.metadata, expected_type)
@@ -535,10 +521,8 @@ def test_make_bulk_create_objects(
         assert (
             ds.make_immuta_datasource_name(
                 table=table,
-                schema="bar" if prefix_query_engine_names_with_schema else "",
-                handler_type=handler_type
-                if prefix_query_engine_names_with_handler
-                else "",
+                schema="bar",
+                handler_type=handler_type,
                 user_prefix="",
             )
             in table_names

--- a/fh_immuta_utils/tests/test_data_source.py
+++ b/fh_immuta_utils/tests/test_data_source.py
@@ -264,7 +264,7 @@ COLUMNS = [
 
 ObjectTestKeys = namedtuple(
     "ObjectTestKeys",
-    ["db_keys", "handler_type", "expected_type", "columns", "query_engine_target_schema", "prefix_names_with_schema", "prefix_names_with_handler"]
+    ["db_keys", "handler_type", "expected_type", "columns", "query_engine_target_schema", "prefix_query_engine_names_with_schema", "prefix_query_engine_names_with_handler"]
 )
 OBJECT_TESTS = [
     ObjectTestKeys(
@@ -273,8 +273,8 @@ OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         columns=COLUMNS,
         query_engine_target_schema="",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
     ),
     ObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -282,8 +282,8 @@ OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         columns=COLUMNS,
         query_engine_target_schema="",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
     ),
     ObjectTestKeys(
         db_keys={
@@ -295,8 +295,8 @@ OBJECT_TESTS = [
         expected_type=ds.AthenaHandlerMetadata,
         columns=COLUMNS,
         query_engine_target_schema="",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
     ),
     ObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -304,8 +304,8 @@ OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         columns=COLUMNS,
         query_engine_target_schema="foo_schema",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
     ),
     ObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -313,8 +313,8 @@ OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         columns=COLUMNS,
         query_engine_target_schema="",
-        prefix_names_with_schema=True,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=True,
+        prefix_query_engine_names_with_handler=False,
     ),
     ObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -322,8 +322,8 @@ OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         columns=COLUMNS,
         query_engine_target_schema="",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=True,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=True,
     ),
     ObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -331,21 +331,21 @@ OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         columns=COLUMNS,
         query_engine_target_schema="",
-        prefix_names_with_schema=True,
-        prefix_names_with_handler=True,
+        prefix_query_engine_names_with_schema=True,
+        prefix_query_engine_names_with_handler=True,
     ),
 ]
 
 
-@pytest.mark.parametrize("db_keys,handler_type,expected_type,columns,query_engine_target_schema,prefix_names_with_schema,prefix_names_with_handler", OBJECT_TESTS)
+@pytest.mark.parametrize("db_keys,handler_type,expected_type,columns,query_engine_target_schema,prefix_query_engine_names_with_schema,prefix_query_engine_names_with_handler", OBJECT_TESTS)
 def test_to_immuta_objects(
     db_keys: Dict[str, str],
     handler_type: str,
     expected_type: Any,
     columns: List[ds.DataSourceColumn],
     query_engine_target_schema: str,
-    prefix_names_with_schema: bool,
-    prefix_names_with_handler: bool,
+    prefix_query_engine_names_with_schema: bool,
+    prefix_query_engine_names_with_handler: bool,
 ):
     base_config = {
         "username": "foo",
@@ -362,19 +362,19 @@ def test_to_immuta_objects(
         config=config,
         columns=columns,
         bodata_schema_name=bodata_schema_name,
-        prefix_names_with_schema=prefix_names_with_schema,
-        prefix_names_with_handler=prefix_names_with_handler,
+        prefix_query_engine_names_with_schema=prefix_query_engine_names_with_schema,
+        prefix_query_engine_names_with_handler=prefix_query_engine_names_with_handler,
     )
     assert source.name == ds.make_immuta_datasource_name(
         table="foo",
-        schema="bar" if prefix_names_with_schema else "",
-        handler_type=handler_type if prefix_names_with_handler else "",
+        schema="bar",
+        handler_type=handler_type,
         user_prefix="",
     )
     assert source.sqlTableName == ds.make_postgres_table_name(
         table="foo",
-        schema="bar" if prefix_names_with_schema else "",
-        handler_type=handler_type if prefix_names_with_handler else "",
+        schema="bar" if prefix_query_engine_names_with_schema else "",
+        handler_type=handler_type if prefix_query_engine_names_with_handler else "",
         user_prefix="",
     )
     assert source.blobHandlerType == handler_type
@@ -386,7 +386,7 @@ def test_to_immuta_objects(
 
 TABLES = ["foo", "bar", "baz"]
 BulkObjectTestKeys = namedtuple(
-    "BulkObjectTestKeys", ["db_keys", "handler_type", "expected_type", "tables", "query_engine_target_schema", "prefix_names_with_schema", "prefix_names_with_handler"]
+    "BulkObjectTestKeys", ["db_keys", "handler_type", "expected_type", "tables", "query_engine_target_schema", "prefix_query_engine_names_with_schema", "prefix_query_engine_names_with_handler"]
 )
 BULK_OBJECT_TESTS = [
     BulkObjectTestKeys(
@@ -395,8 +395,8 @@ BULK_OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         tables=[],
         query_engine_target_schema="",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
     ),
     BulkObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -404,8 +404,8 @@ BULK_OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         tables=TABLES,
         query_engine_target_schema="",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
     ),
     BulkObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -413,8 +413,8 @@ BULK_OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         tables=TABLES,
         query_engine_target_schema="",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
     ),
     BulkObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -422,8 +422,8 @@ BULK_OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         tables=TABLES,
         query_engine_target_schema="foo_schema",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
     ),
     BulkObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -431,8 +431,8 @@ BULK_OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         tables=TABLES,
         query_engine_target_schema="",
-        prefix_names_with_schema=True,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=True,
+        prefix_query_engine_names_with_handler=False,
     ),
     BulkObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -440,8 +440,8 @@ BULK_OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         tables=TABLES,
         query_engine_target_schema="",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=True,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=True,
     ),
     BulkObjectTestKeys(
         db_keys={"hostname": "qux"},
@@ -449,8 +449,8 @@ BULK_OBJECT_TESTS = [
         expected_type=ds.PostgresHandlerMetadata,
         tables=TABLES,
         query_engine_target_schema="",
-        prefix_names_with_schema=True,
-        prefix_names_with_handler=True,
+        prefix_query_engine_names_with_schema=True,
+        prefix_query_engine_names_with_handler=True,
     ),
     BulkObjectTestKeys(
         db_keys={
@@ -462,21 +462,21 @@ BULK_OBJECT_TESTS = [
         expected_type=ds.AthenaHandlerMetadata,
         tables=TABLES,
         query_engine_target_schema="",
-        prefix_names_with_schema=False,
-        prefix_names_with_handler=False,
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
     ),
 ]
 
 
-@pytest.mark.parametrize("db_keys,handler_type,expected_type,tables,query_engine_target_schema,prefix_names_with_schema,prefix_names_with_handler", BULK_OBJECT_TESTS)
+@pytest.mark.parametrize("db_keys,handler_type,expected_type,tables,query_engine_target_schema,prefix_query_engine_names_with_schema,prefix_query_engine_names_with_handler", BULK_OBJECT_TESTS)
 def test_make_bulk_create_objects(
     db_keys: Dict[str, str],
     handler_type: str,
     expected_type: Any,
     tables: List[str],
     query_engine_target_schema: str,
-    prefix_names_with_schema: bool,
-    prefix_names_with_handler: bool,
+    prefix_query_engine_names_with_schema: bool,
+    prefix_query_engine_names_with_handler: bool,
 ):
     base_config = {
         "username": "foo",
@@ -493,8 +493,8 @@ def test_make_bulk_create_objects(
         schema="bar",
         config=config,
         bodata_schema_name=bodata_schema_name,
-        prefix_names_with_schema=prefix_names_with_schema,
-        prefix_names_with_handler=prefix_names_with_handler,
+        prefix_query_engine_names_with_schema=prefix_query_engine_names_with_schema,
+        prefix_query_engine_names_with_handler=prefix_query_engine_names_with_handler,
     )
     assert len(handlers) == len(tables)
     assert source.blobHandlerType == handler_type
@@ -510,8 +510,8 @@ def test_make_bulk_create_objects(
         assert (
             ds.make_immuta_datasource_name(
                 table=table,
-                schema="bar" if prefix_names_with_schema else "",
-                handler_type=handler_type if prefix_names_with_handler else "",
+                schema="bar" if prefix_query_engine_names_with_schema else "",
+                handler_type=handler_type if prefix_query_engine_names_with_handler else "",
                 user_prefix=""
             )
             in table_names
@@ -531,7 +531,7 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
             disabled=True,
             config=ds.SchemaEvolutionMetadataConfig(
                 nameTemplate={
-                    "dataSourceNameFormat": "<tablename>",
+                    "dataSourceNameFormat": "rs_<schema>_<tablename>",
                     "queryEngineTableNameFormat": "<tablename>",
                     "queryEngineSchemaNameFormat": "<schema>",
                 }
@@ -548,7 +548,7 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
             disabled=True,
             config=ds.SchemaEvolutionMetadataConfig(
                 nameTemplate={
-                    "dataSourceNameFormat": "<tablename>",
+                    "dataSourceNameFormat": "ath_<schema>_<tablename>",
                     "queryEngineTableNameFormat": "<tablename>",
                     "queryEngineSchemaNameFormat": "<schema>",
                 }
@@ -566,7 +566,7 @@ SCHEMA_EVOLUTION_METADATA_TESTS = {
             disabled=True,
             config=ds.SchemaEvolutionMetadataConfig(
                 nameTemplate={
-                    "dataSourceNameFormat": "foobar_<tablename>",
+                    "dataSourceNameFormat": "foobar_ath_<schema>_<tablename>",
                     "queryEngineTableNameFormat": "foobar_<tablename>",
                     "queryEngineSchemaNameFormat": "<schema>",
                 }

--- a/fh_immuta_utils/tests/test_tagging.py
+++ b/fh_immuta_utils/tests/test_tagging.py
@@ -7,7 +7,12 @@ import fh_immuta_utils.tagging as tg
 import fh_immuta_utils.data_source as ds
 
 TAG_MAP = {"col_foo": ["foo", "foobar"], "col_bar": ["bar.baz"]}
-DATA_SOURCE_TAGS = {("handler_foo", "database_foo"): {"ath_match*": ["eeny", "meeny.miny"], "rs_fail*": ["moe"]}}
+DATA_SOURCE_TAGS = {
+    ("handler_foo", "database_foo"): {
+        "ath_match*": ["eeny", "meeny.miny"],
+        "rs_fail*": ["moe"],
+    }
+}
 
 
 @pytest.fixture
@@ -48,21 +53,30 @@ def test_get_tags_for_data_source(tagger):
         {"name": "meeny.miny", "source": "curated"},
     ]
 
-    assert tagger.get_tags_for_data_source(
-        name="ath_match_succeeds",
-        handler_type="handler_foo",
-        connection_string="fake.connection.string:5439/database_foo"
-    ) == expected
-    assert tagger.get_tags_for_data_source(
-        name="ath_fail_match",
-        handler_type="handler_foo",
-        connection_string="fake.connection.string:5439/database_foo"
-    ) == []
-    assert tagger.get_tags_for_data_source(
-        name="rs_fail_bar",
-        handler_type="handler_fail_match",
-        connection_string="fake.connection.string:5439/database_fail_match"
-    ) == []
+    assert (
+        tagger.get_tags_for_data_source(
+            name="ath_match_succeeds",
+            handler_type="handler_foo",
+            connection_string="fake.connection.string:5439/database_foo",
+        )
+        == expected
+    )
+    assert (
+        tagger.get_tags_for_data_source(
+            name="ath_fail_match",
+            handler_type="handler_foo",
+            connection_string="fake.connection.string:5439/database_foo",
+        )
+        == []
+    )
+    assert (
+        tagger.get_tags_for_data_source(
+            name="rs_fail_bar",
+            handler_type="handler_fail_match",
+            connection_string="fake.connection.string:5439/database_fail_match",
+        )
+        == []
+    )
 
 
 TagMsgBody = namedtuple("TagMsgBody", ["root_tag", "children", "expected"])

--- a/fh_immuta_utils/tests/test_tagging.py
+++ b/fh_immuta_utils/tests/test_tagging.py
@@ -7,7 +7,7 @@ import fh_immuta_utils.tagging as tg
 import fh_immuta_utils.data_source as ds
 
 TAG_MAP = {"col_foo": ["foo", "foobar"], "col_bar": ["bar.baz"]}
-DATA_SOURCE_TAGS = {"ath_succeed": ["eeny", "meeny.miny"], "rs_fail": ["moe"]}
+DATA_SOURCE_TAGS = {("handler_foo", "database_foo"): {"ath_match*": ["eeny", "meeny.miny"], "rs_fail*": ["moe"]}}
 
 
 @pytest.fixture
@@ -47,8 +47,22 @@ def test_get_tags_for_data_source(tagger):
         {"name": "eeny", "source": "curated"},
         {"name": "meeny.miny", "source": "curated"},
     ]
-    assert tagger.get_tags_for_data_source(name="ath_succeed_foo") == expected
-    assert tagger.get_tags_for_data_source(name="ath_fail_bar") == []
+
+    assert tagger.get_tags_for_data_source(
+        name="ath_match_succeeds",
+        handler_type="handler_foo",
+        connection_string="fake.connection.string:5439/database_foo"
+    ) == expected
+    assert tagger.get_tags_for_data_source(
+        name="ath_fail_match",
+        handler_type="handler_foo",
+        connection_string="fake.connection.string:5439/database_foo"
+    ) == []
+    assert tagger.get_tags_for_data_source(
+        name="rs_fail_bar",
+        handler_type="handler_fail_match",
+        connection_string="fake.connection.string:5439/database_fail_match"
+    ) == []
 
 
 TagMsgBody = namedtuple("TagMsgBody", ["root_tag", "children", "expected"])

--- a/release_notes/@vNext.md
+++ b/release_notes/@vNext.md
@@ -2,23 +2,19 @@
 
 ## Compatible with Immuta version `<=2020.3.4`
 
-### Added
-
 ### Changed
-- BREAKING CHANGE: Data source-level tag keys defined in dataset configuration file will match data source names 
+- BREAKING CHANGE: Data source-level tag keys defined in dataset configuration file will match data source names
   using Unix shell-style wildcard matching. This aligns with data source schema and table prefix matching used for the
   `schemas_to_enroll` and `schemas_to_bulk_enroll` keys.
 - BREAKING CHANGE: Data sources will enroll under their original schema name from the remote database in the Query
   Engine unless the `query_engine_target_schema` parameter is provided to override in the dataset configuration file.
   This aligns with the Immuta UI default value.
-- BREAKING CHANGE: Opt in is now required in the dataset configuration file to prefix data source and query engine table
-  names with handler and schema names using the `prefix_names_with_schema` and `prefix_names_with_handler` flags. This
-  aligns with the Immuta UI default values.
-- BREAKING CHANGE: Defaults for schema monitoring template parameters `datasource_name_format_default` and
-  `query_engine_table_name_format_default` do not include handler and schema name prefixes to align with the Immuta UI
-  default values.
+- BREAKING CHANGE: Opt-in is now required in the dataset configuration file to prefix Query Engine table names with
+  the handler and schema using the `prefix_query_engine_names_with_schema` and `prefix_query_engine_names_with_handler`
+  flags. This aligns with the Immuta UI default values.
+- BREAKING CHANGE: The default value for schema monitoring template parameter `query_engine_table_name_format_default`
+  no longer includes handler and schema prefixes. This aligns with the Immuta UI default value.
 ### Fixed
 - Data source-level tags apply only to data sources created by the dataset configuration file in which they are defined.
   This now matches what the documentation originally stated.
 - `user_prefix` from dataset configuration files is now being pulled correctly for schema monitoring templating.
-  

--- a/release_notes/@vNext.md
+++ b/release_notes/@vNext.md
@@ -1,1 +1,24 @@
-<!-- to be filled in -->
+# 0.5.0 (2021-03-24)
+
+## Compatible with Immuta version `<=2020.3.4`
+
+### Added
+
+### Changed
+- BREAKING CHANGE: Data source-level tag keys defined in dataset configuration file will match data source names 
+  using Unix shell-style wildcard matching. This aligns with data source schema and table prefix matching used for the
+  `schemas_to_enroll` and `schemas_to_bulk_enroll` keys.
+- BREAKING CHANGE: Data sources will enroll under their original schema name from the remote database in the Query
+  Engine unless the `query_engine_target_schema` parameter is provided to override in the dataset configuration file.
+  This aligns with the Immuta UI default value.
+- BREAKING CHANGE: Opt in is now required in the dataset configuration file to prefix data source and query engine table
+  names with handler and schema names using the `prefix_names_with_schema` and `prefix_names_with_handler` flags. This
+  aligns with the Immuta UI default values.
+- BREAKING CHANGE: Defaults for schema monitoring template parameters `datasource_name_format_default` and
+  `query_engine_table_name_format_default` do not include handler and schema name prefixes to align with the Immuta UI
+  default values.
+### Fixed
+- Data source-level tags apply only to data sources created by the dataset configuration file in which they are defined.
+  This now matches what the documentation originally stated.
+- `user_prefix` from dataset configuration files is now being pulled correctly for schema monitoring templating.
+  


### PR DESCRIPTION
Multiple breaking changes for data source enrollment to align with Immuta UI default values along with some fixes to the tagging functionality. Namely:

**Data source enrollment**

- BREAKING CHANGE: Data sources will enroll under their original schema name from the remote database in the Query Engine unless the `query_engine_target_schema` parameter is provided in the dataset configuration file to override. This aligns with the Immuta UI default value.
- BREAKING CHANGE: Opt-in is now required in the dataset configuration file to prefix Query Engine table names with the handler and schema using the `prefix_query_engine_names_with_schema` and `prefix_query_engine_names_with_handler` flags. This aligns with the Immuta UI default values.
- BREAKING CHANGE: The default value for schema monitoring template parameter `query_engine_table_name_format_default` no longer includes handler and schema prefixes. This aligns with the Immuta UI default value.
- `user_prefix` from dataset configuration files is now being pulled correctly for schema monitoring templating.

**Tagging**

- Data source-level tags apply only to data sources created by the dataset configuration file in which they are defined. This now matches what the documentation originally stated.
- BREAKING CHANGE: Data source-level tag keys defined in dataset configuration file will match data source names using Unix shell-style wildcard matching. This aligns with data source schema and table prefix matching used for the `schemas_to_enroll` and `schemas_to_bulk_enroll` functionality.