### PR TITLE
Add support for enrolling Snowflake data sources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
     - id: trailing-whitespace
 - repo: https://github.com/python/black
-  rev: master
+  rev: 21.6b0
   hooks:
     - id: black
       exclude : >

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,10 @@ repos:
           versioneer.py
         )$
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910
+  rev: v0.800
   hooks:
     - id: mypy
-      args: [--no-strict-optional, --ignore-missing-imports]
+      args: [--ignore-missing-imports]
       exclude : >
         (?x)^(
           immuta_utils/_version.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,10 @@ repos:
           versioneer.py
         )$
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: master
+  rev: v0.910
   hooks:
     - id: mypy
+      args: [--no-strict-optional, --ignore-missing-imports]
       exclude : >
         (?x)^(
           immuta_utils/_version.py|

--- a/doc/managing_configs.md
+++ b/doc/managing_configs.md
@@ -99,7 +99,16 @@ tags:
   "pg_foo*": ["tag3", "tag4"]
 ```
 
-**Note:** For AWS Redshift, use the same format as above, replacing the `handler_type` value with `Redshift`.
+#### AWS Redshift
+
+Use the same format as PostgreSQL, replacing the `handler_type` value with `Redshift`.
+
+#### Snowflake
+
+Use the same format as PostgreSQL, replacing the `handler_type` value with `Snowflake`. Additional parameters include:
+
+1. `warehouse`: Required. Specifies the Snowflake warehouse to use when interacting with the Immuta database in Snowflake
+2. `secureNativeView`: Defaults to `false`. Enables or disables secure views for all enrolled Snowflake data sources.
 
 #### AWS Athena
 

--- a/fh_immuta_utils/authenticate.py
+++ b/fh_immuta_utils/authenticate.py
@@ -194,7 +194,7 @@ def build_auth_scheme(**kwargs):
 
 
 def retrieve_credentials_from_vault(credentials_dict: Dict[str, Any]) -> Dict[str, str]:
-    """ Expects that you're logged into Hashicorp Vault. """
+    """Expects that you're logged into Hashicorp Vault."""
     import hvac
 
     client = hvac.Client()
@@ -210,7 +210,7 @@ def retrieve_credentials_from_vault(credentials_dict: Dict[str, Any]) -> Dict[st
 def retrieve_credentials_from_environment(
     credentials_dict: Dict[str, Any]
 ) -> Dict[str, str]:
-    """ Will throw if env var is unset. """
+    """Will throw if env var is unset."""
     try:
         credentials_dict["value"] = os.environ[credentials_dict["key"]]
     except KeyError:

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -103,6 +103,10 @@ class ImmutaClient(LoggingMixin):
             return cls.make_generic_odbc_request_headers(config)
         if config["handler_type"] == "Amazon Athena":
             return cls.make_athena_glob_request_headers(config)
+        if config["handler_type"] == "Snowflake":
+            headers = cls.make_generic_odbc_request_headers(config)
+            headers["sql-warehouse"] = config["warehouse"]
+            return headers
         raise TypeError
 
     @classmethod

--- a/fh_immuta_utils/config.py
+++ b/fh_immuta_utils/config.py
@@ -10,7 +10,7 @@ REQUIRED_KEYS = ["base_url", "config_root", "auth_config"]
 
 
 def parse_config(config_file: str) -> Dict[str, Any]:
-    """ Validates the given config file and returns as dict """
+    """Validates the given config file and returns as dict"""
     with open(config_file) as handle:
         config = yaml.safe_load(handle)
     for key in REQUIRED_KEYS:

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -334,8 +334,8 @@ def make_handler_metadata(
     }
     for k, v in required_args.items():
         config[k] = config.get(k, v)
-    if 'bodataSchemaName' in kwargs:
-        kwargs['bodataSchemaName'] = kwargs['bodataSchemaName'].lower()
+    if "bodataSchemaName" in kwargs:
+        kwargs["bodataSchemaName"] = kwargs["bodataSchemaName"].lower()
     if config["handler_type"] == "Amazon Athena":
         metadata = AthenaHandlerMetadata(
             # Default value but has to exist in the final used dict

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -25,7 +25,7 @@ class Tag(BaseModel):
 
 
 class Tagger(object):
-    """ Wrapper around managing tags. """
+    """Wrapper around managing tags."""
 
     def __init__(self, config_root: str) -> None:
         # column_name: [tag1, tag2, ...]

--- a/fh_immuta_utils/tests/test_client.py
+++ b/fh_immuta_utils/tests/test_client.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+import pytest
+
+from fh_immuta_utils.client import ImmutaClient
+
+
+MAKE_GLOB_REQUEST_HEADERS_TESTS = {
+    "make_glob_request_headers_postgresql": (
+        {
+            "handler_type": "PostgreSQL",
+            "hostname": "psql.foobar.io",
+            "port": 443,
+            "username": "foo",
+            "password": "bar",
+        },
+        {
+            "sql-hostname": "psql.foobar.io",
+            "sql-port": "443",
+            "sql-ssl": "true",
+            "sql-username": "foo",
+            "sql-password": "bar",
+        },
+    ),
+    "make_glob_request_headers_athena": (
+        {
+            "handler_type": "Amazon Athena",
+            "region": "us-east-1",
+            "queryResultLocationBucket": "s3_location",
+            "username": "foo",
+            "password": "bar",
+        },
+        {
+            "sql-authentication-type": "accessKey",
+            "sql-aws-region": "us-east-1",
+            "sql-aws-result-location": "s3_location",
+            "sql-ssl": "true",
+            "sql-username": "foo",
+            "sql-password": "bar",
+        },
+    ),
+    "make_glob_request_headers_snowflake": (
+        {
+            "handler_type": "Snowflake",
+            "hostname": "psql.foobar.io",
+            "port": 443,
+            "username": "foo",
+            "password": "bar",
+            "warehouse": "IMMUTA_WH",
+        },
+        {
+            "sql-hostname": "psql.foobar.io",
+            "sql-port": "443",
+            "sql-ssl": "true",
+            "sql-username": "foo",
+            "sql-password": "bar",
+            "sql-warehouse": "IMMUTA_WH",
+        },
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    list(MAKE_GLOB_REQUEST_HEADERS_TESTS.values()),
+    ids=list(MAKE_GLOB_REQUEST_HEADERS_TESTS.keys()),
+)
+@patch("fh_immuta_utils.client.ImmutaSession")
+def test_skip_dataset_enrollment(mock_session, config, expected):
+    client = ImmutaClient(session=mock_session)
+    assert client.make_glob_request_headers(config) == expected

--- a/fh_immuta_utils/tests/test_data_source.py
+++ b/fh_immuta_utils/tests/test_data_source.py
@@ -66,6 +66,13 @@ IMMUTA_DATASOURCE_NAME_TESTS = [
         user_prefix="",
         expected_name=f"{ds.PREFIX_MAP['Amazon Athena']}_foo_barbazquxquux",
     ),
+    NameTestKeys(
+        handler_type="Snowflake",
+        schema="foo",
+        table="barbazquxquux",
+        user_prefix="",
+        expected_name=f"{ds.PREFIX_MAP['Snowflake']}_foo_barbazquxquux",
+    ),
 ]
 
 
@@ -137,6 +144,13 @@ POSTGRES_NAME_TESTS = [
         user_prefix="",
         expected_name=f"{ds.PREFIX_MAP['Amazon Athena']}_foo_barbazquxquux",
     ),
+    NameTestKeys(
+        handler_type="Snowflake",
+        schema="foo",
+        table="barbazquxquux",
+        user_prefix="",
+        expected_name=f"{ds.PREFIX_MAP['Snowflake']}_foo_barbazquxquux",
+    ),
 ]
 
 
@@ -183,6 +197,12 @@ HANDLER_METADATA_TESTS = [
         db_keys={"hostname": "qux"},
         handler_type="Redshift",
         expected_type=ds.PostgresHandlerMetadata,
+        kwargs={},
+    ),
+    MetadataTestKeys(
+        db_keys={"hostname": "qux", "warehouse": "IMMUTA_WH"},
+        handler_type="Snowflake",
+        expected_type=ds.SnowflakeHandlerMetadata,
         kwargs={},
     ),
     MetadataTestKeys(
@@ -291,6 +311,15 @@ OBJECT_TESTS = [
         },
         handler_type="Amazon Athena",
         expected_type=ds.AthenaHandlerMetadata,
+        columns=COLUMNS,
+        query_engine_target_schema="",
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
+    ),
+    ObjectTestKeys(
+        db_keys={"hostname": "qux", "warehouse": "IMMUTA_WH"},
+        handler_type="Snowflake",
+        expected_type=ds.SnowflakeHandlerMetadata,
         columns=COLUMNS,
         query_engine_target_schema="",
         prefix_query_engine_names_with_schema=False,
@@ -469,6 +498,15 @@ BULK_OBJECT_TESTS = [
         },
         handler_type="Amazon Athena",
         expected_type=ds.AthenaHandlerMetadata,
+        tables=TABLES,
+        query_engine_target_schema="",
+        prefix_query_engine_names_with_schema=False,
+        prefix_query_engine_names_with_handler=False,
+    ),
+    BulkObjectTestKeys(
+        db_keys={"hostname": "qux", "warehouse": "IMMUTA_WH"},
+        handler_type="Snowflake",
+        expected_type=ds.SnowflakeHandlerMetadata,
         tables=TABLES,
         query_engine_target_schema="",
         prefix_query_engine_names_with_schema=False,

--- a/release_notes/@vNext.md
+++ b/release_notes/@vNext.md
@@ -1,0 +1,6 @@
+# 0.5.1 (2021-06-25)
+
+## Compatible with Immuta version `>=2021.1.2`
+
+### Added
+- Support for Snowflake handler. Users can now enroll Snowflake data sources and enable Secure Views on those data sources.


### PR DESCRIPTION
Adds support for the Snowflake handler and metadata. Secure views can be enabled for enrolled data sources.

Tested on Immuta app v2021.1.2