### PR TITLE
update codecov to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
         pytest --cov=./ --cov-report=xml --cov-config=./.coveragerc
 
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true
-


### PR DESCRIPTION
Update codecov action to v2

See also: 
- https://github.com/ansible-collections/community.hashi_vault/pull/108
- https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1
- https://github.com/codecov/codecov-action/pull/392
- https://docs.codecov.com/docs/about-the-codecov-bash-uploader
- https://docs.codecov.com/docs/codecov-uploader
