### PR TITLE
Bug fixes and add ability to search by schema

### DIFF
--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -538,7 +538,7 @@ class ImmutaClient(LoggingMixin):
         """
         request_prefix = blob_handler_type(dataset_spec["handler_type"])
         remote_database = dataset_spec["database"]
-        headers = self.make_generic_odbc_request_headers(dataset_spec)
+        headers = self.make_glob_request_headers(dataset_spec)
         path = f"{request_prefix}/database/{remote_database}/test"
         res = self._session.get(path, headers=headers)
         return res

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -507,7 +507,9 @@ class ImmutaClient(LoggingMixin):
             result = self.delete(f"dataSource/{id}")
             result_json = result.json()
 
-            if ("hardDelete" not in result_json) or ("hardDelete" in result_json and not result_json["hardDelete"]):
+            if ("hardDelete" not in result_json) or (
+                "hardDelete" in result_json and not result_json["hardDelete"]
+            ):
                 # if the data source was only disabled, delete it again
                 self.delete(f"dataSource/{id}")
         except HTTPError as e:

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -136,6 +136,7 @@ class ImmutaClient(LoggingMixin):
     def make_get_request_params(
         cls,
         search_text: Optional[str] = None,
+        search_schema: Optional[str] = None,
         public_only: Optional[bool] = None,
         name_only: Optional[bool] = False,
         mode: Optional[int] = 0,
@@ -144,6 +145,7 @@ class ImmutaClient(LoggingMixin):
     ) -> Dict[str, Any]:
         params = {
             "searchText": search_text,
+            "schema": search_schema,
             "publicOnly": public_only,
             "nameOnly": name_only,
             "mode": mode,
@@ -375,6 +377,7 @@ class ImmutaClient(LoggingMixin):
     def get_data_source_list(
         self,
         search_text=None,
+        search_schema=None,
         public_only=None,
         name_only=False,
         mode=0,
@@ -383,6 +386,7 @@ class ImmutaClient(LoggingMixin):
     ):
         params = self.make_get_request_params(
             search_text=search_text,
+            search_schema=search_schema,
             public_only=public_only,
             name_only=name_only,
             mode=mode,

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -500,13 +500,14 @@ class ImmutaClient(LoggingMixin):
             if not id and name:
                 id = self.get_data_source_by_name(name=name)["id"]
 
-            # To completely remove a data source, we need to disabled it first,
+            # To completely remove a data source, we need to disable it first,
             # but Immuta uses the same endpoint for both actions,
             # Due to this reason, we run `self.delete()` twice
             # unless the data source was already disabled
             result = self.delete(f"dataSource/{id}")
+            result_json = result.json()
 
-            if not result.json()["hardDelete"]:
+            if ("hardDelete" not in result_json) or ("hardDelete" in result_json and not result_json["hardDelete"]):
                 # if the data source was only disabled, delete it again
                 self.delete(f"dataSource/{id}")
         except HTTPError as e:

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -153,6 +153,7 @@ class DataSourceColumn(BaseModel):
     dataType: str
     remoteType: str
     nullable: bool
+    remoteColumn: str = ""
     tags: List[Dict[str, str]] = []
 
 

--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -218,6 +218,7 @@ HANDLER_TO_METADATA_CLASS = {
     "PostgreSQL": PostgresHandlerMetadata,
     "Amazon Athena": AthenaHandlerMetadata,
     "Redshift": PostgresHandlerMetadata,
+    "Snowflake": SnowflakeHandlerMetadata,
 }
 
 

--- a/fh_immuta_utils/scripts/bulk_delete_data_source.py
+++ b/fh_immuta_utils/scripts/bulk_delete_data_source.py
@@ -34,7 +34,12 @@ LOGGER = logging.getLogger(__name__)
 )
 @click.option("--debug", is_flag=True, default=False, help="Debug logging")
 def main(
-    config_file: str, search_text: str, search_schema: str, hard_delete: bool, dry_run: bool, debug: bool
+    config_file: str,
+    search_text: str,
+    search_schema: str,
+    hard_delete: bool,
+    dry_run: bool,
+    debug: bool,
 ):
     logging.basicConfig(
         format="[%(name)s][%(levelname)s][%(asctime)s] %(message)s",
@@ -46,7 +51,11 @@ def main(
 
     logging.info("Gathering data-stores to delete")
     data_sources_to_delete = []
-    with Paginator(client.get_data_source_list, search_text=search_text, search_schema=search_schema) as paginator:
+    with Paginator(
+        client.get_data_source_list,
+        search_text=search_text,
+        search_schema=search_schema,
+    ) as paginator:
         for data_source in paginator:
             data_sources_to_delete.append(
                 {"id": data_source["id"], "name": data_source["name"]}

--- a/fh_immuta_utils/scripts/bulk_delete_data_source.py
+++ b/fh_immuta_utils/scripts/bulk_delete_data_source.py
@@ -17,6 +17,10 @@ LOGGER = logging.getLogger(__name__)
     help="Delete the data sources that contains this string in their name",
 )
 @click.option(
+    "--search-schema",
+    help="Delete the data sources that match this schema",
+)
+@click.option(
     "--hard-delete",
     is_flag=True,
     default=False,
@@ -30,7 +34,7 @@ LOGGER = logging.getLogger(__name__)
 )
 @click.option("--debug", is_flag=True, default=False, help="Debug logging")
 def main(
-    config_file: str, search_text: str, hard_delete: bool, dry_run: bool, debug: bool
+    config_file: str, search_text: str, search_schema: str, hard_delete: bool, dry_run: bool, debug: bool
 ):
     logging.basicConfig(
         format="[%(name)s][%(levelname)s][%(asctime)s] %(message)s",
@@ -42,7 +46,7 @@ def main(
 
     logging.info("Gathering data-stores to delete")
     data_sources_to_delete = []
-    with Paginator(client.get_data_source_list, search_text=search_text) as paginator:
+    with Paginator(client.get_data_source_list, search_text=search_text, search_schema=search_schema) as paginator:
         for data_source in paginator:
             data_sources_to_delete.append(
                 {"id": data_source["id"], "name": data_source["name"]}

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -33,13 +33,21 @@ from fh_immuta_utils.tagging import Tagger
     help="Log the data stores that would be updated without affecting any change",
 )
 @click.option("--debug", is_flag=True, default=False, help="Debug logging")
-def cli_entrypoint(config_file: str, search_text: str, search_schema: str, dry_run: bool, debug: bool):
+def cli_entrypoint(
+    config_file: str, search_text: str, search_schema: str, dry_run: bool, debug: bool
+):
     return main(
-        config_file=config_file, search_text=search_text, search_schema=search_schema, dry_run=dry_run, debug=debug
+        config_file=config_file,
+        search_text=search_text,
+        search_schema=search_schema,
+        dry_run=dry_run,
+        debug=debug,
     )
 
 
-def main(config_file: str, search_text: str, search_schema: str,  dry_run: bool, debug: bool):
+def main(
+    config_file: str, search_text: str, search_schema: str, dry_run: bool, debug: bool
+):
     logging.basicConfig(
         format="[%(name)s][%(levelname)s][%(asctime)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
@@ -54,7 +62,11 @@ def main(config_file: str, search_text: str, search_schema: str,  dry_run: bool,
 
     logging.info("Gathering data sources to tag")
     data_sources_to_tag = []
-    with Paginator(client.get_data_source_list, search_text=search_text, search_schema=search_schema) as paginator:
+    with Paginator(
+        client.get_data_source_list,
+        search_text=search_text,
+        search_schema=search_schema,
+    ) as paginator:
         for data_source in paginator:
             data_sources_to_tag.append(
                 {

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -20,7 +20,11 @@ from fh_immuta_utils.tagging import Tagger
 @click.option("--config-file", required=True)
 @click.option(
     "--search-text",
-    help="Will match all data sources that contains this string anywhere in their name",
+    help="Will match all data sources that contain this string anywhere in their name",
+)
+@click.option(
+    "--search-schema",
+    help="Will match all data sources that match this schema",
 )
 @click.option(
     "--dry-run",
@@ -29,13 +33,13 @@ from fh_immuta_utils.tagging import Tagger
     help="Log the data stores that would be updated without affecting any change",
 )
 @click.option("--debug", is_flag=True, default=False, help="Debug logging")
-def cli_entrypoint(config_file: str, search_text: str, dry_run: bool, debug: bool):
+def cli_entrypoint(config_file: str, search_text: str, search_schema: str, dry_run: bool, debug: bool):
     return main(
-        config_file=config_file, search_text=search_text, dry_run=dry_run, debug=debug
+        config_file=config_file, search_text=search_text, search_schema=search_schema, dry_run=dry_run, debug=debug
     )
 
 
-def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
+def main(config_file: str, search_text: str, search_schema: str,  dry_run: bool, debug: bool):
     logging.basicConfig(
         format="[%(name)s][%(levelname)s][%(asctime)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
@@ -50,7 +54,7 @@ def main(config_file: str, search_text: str, dry_run: bool, debug: bool):
 
     logging.info("Gathering data sources to tag")
     data_sources_to_tag = []
-    with Paginator(client.get_data_source_list, search_text=search_text) as paginator:
+    with Paginator(client.get_data_source_list, search_text=search_text, search_schema=search_schema) as paginator:
         for data_source in paginator:
             data_sources_to_tag.append(
                 {

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -174,7 +174,7 @@ class Tagger(object):
             # We don't know what other possible values exist for source, but all our currently made tags
             # are curated.
             column.tags = [
-                {"name": tag, "source": "curated"}
+                {"name": tag, "source": "curated", "deleted": "False"}
                 for tag in self.get_tags_for_column(column_name=column.name)
             ]
             enriched_columns.append(column)

--- a/fh_immuta_utils/tests/test_client.py
+++ b/fh_immuta_utils/tests/test_client.py
@@ -1,8 +1,8 @@
-from contextlib import nullcontext as does_not_raise
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock
 
 import pytest
 import requests
+from requests import Response
 
 from fh_immuta_utils.client import ImmutaClient
 
@@ -80,3 +80,16 @@ def test_delete_data_source_no_id_no_name(mock_session):
     name = None
     with pytest.raises(Exception):
         client.delete_data_source(id=id, name=name)
+
+
+@patch("fh_immuta_utils.client.ImmutaSession")
+def test_delete_data_source_already_disabled(mock_session):
+    client = ImmutaClient(session=mock_session)
+    id = 1
+    name = None
+    client.delete = Mock()
+    resp = Mock(spec=Response)
+    resp.json.return_value = {"hardDelete": True}
+    client.delete.return_value = resp
+    client.delete_data_source(id=id, name=name)
+    client.delete.assert_called_once()

--- a/fh_immuta_utils/tests/test_client.py
+++ b/fh_immuta_utils/tests/test_client.py
@@ -1,6 +1,8 @@
-from unittest.mock import patch
+from contextlib import nullcontext as does_not_raise
+from unittest.mock import patch, MagicMock
 
 import pytest
+import requests
 
 from fh_immuta_utils.client import ImmutaClient
 
@@ -69,3 +71,12 @@ MAKE_GLOB_REQUEST_HEADERS_TESTS = {
 def test_skip_dataset_enrollment(mock_session, config, expected):
     client = ImmutaClient(session=mock_session)
     assert client.make_glob_request_headers(config) == expected
+
+
+@patch("fh_immuta_utils.client.ImmutaSession")
+def test_delete_data_source_no_id_no_name(mock_session):
+    client = ImmutaClient(session=mock_session)
+    id = None
+    name = None
+    with pytest.raises(Exception):
+        client.delete_data_source(id=id, name=name)

--- a/release_notes/@vNext.md
+++ b/release_notes/@vNext.md
@@ -1,0 +1,12 @@
+# 0.5.2 (2021-08-03)
+
+## Compatible with Immuta version `>=2021.1.2`
+
+### Added
+- Ability to search by data source schema when bulk deleting or tagging data sources
+
+### Fixed
+- Bug preventing remote columns from persisting after a column is tagged
+- Bug that forced data source dictionary updates when tagging because comparisons were failing
+- Bug preventing correct evaluation of the schema evolution status check for Snowflake remote databases
+- Data source deletion logic to account for updated API response to allow for hard deletes


### PR DESCRIPTION
- Fixed bug preventing remote columns from persisting after a column is tagged
- Fixed bug that forced data source dictionary updates when tagging because comparisons were failing
- Fixed bug preventing correct evaluation of the schema evolution status check for Snowflake remote databases
- Fixed data source deletion logic to account for updated API response to allow for hard deletes
- Added the ability to search by data source schema when bulk deleting data sources or tagging

Tested on Immuta app v2021.1.2