### PR TITLE
Optimize tagging for a large number of data sources (100K+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -36,6 +36,6 @@ jobs:
         pytest --cov=./ --cov-report=xml --cov-config=./.coveragerc
 
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
         run: echo "VER_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: master
+  rev: main
   hooks:
     - id: trailing-whitespace
 - repo: https://github.com/python/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
     - id: trailing-whitespace
 - repo: https://github.com/python/black
-  rev: 21.6b0
+  rev: 22.3.0
   hooks:
     - id: black
       exclude : >

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -399,9 +399,28 @@ class ImmutaClient(LoggingMixin):
         )
         return self.get("dataSource", params=params)
 
-    def get_all_data_source_and_column_tags(self):
-        # note: this is not an official API endpoint
-        return self.get("governance/reports/tag/allUserDataSources")
+    def get_tags(self):
+        return self.get("tag")
+
+    def get_data_source_and_column_tag_info(
+        self, tag_name: Optional[str] = None
+    ) -> List[Dict[str, str]]:
+        """
+        Get info on tagged data sources and columns. If `tag_name` is not None, returns data for only
+        the data sources and columns tagged with `tag_name`.
+
+        Returns a dict for every matching data source and column. Each dict contains at least
+        the following keys:
+           - Type (Data Source or Column)
+           - Data Source
+           - Column Name (value may be N/A)
+           - Tag Name
+        """
+        # note: these are not official API endpoints
+        if tag_name is None:
+            return self.get("governance/reports/tag/allUserDataSources")["hits"]
+        else:
+            return self.get(f"governance/reports/tag/{tag_name}/dataSource")["hits"]
 
     def get_data_source_by_name(self, name):
         endpoint = "dataSource/name/{}".format(name)

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -552,7 +552,9 @@ class ImmutaClient(LoggingMixin):
         self, ids: List[int], tag_data: List[Dict[str, Any]]
     ) -> bool:
         """
-        Adds tags to a list of data sources.
+        Adds tags to a list of data sources. This will apply all tags in tag_data to all data
+        the data sources corresponding to ids.
+
         :param ids: data source ids
         :param tag_data: list of tag dicts to apply to the data sources
         :return: True

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -5,7 +5,9 @@ Script that can be invoked to grep for all existing data sources and then tag co
 within sources as per specified mapping.
 """
 
+from collections import defaultdict
 import logging
+from typing import Dict, Set, Tuple
 
 import click
 from tqdm import tqdm
@@ -13,7 +15,10 @@ from tqdm import tqdm
 from fh_immuta_utils.client import get_client
 from fh_immuta_utils.config import parse_config
 from fh_immuta_utils.paginator import Paginator
-from fh_immuta_utils.tagging import Tagger
+from fh_immuta_utils.tagging import IMMUTA_SPECIAL_TAGS, Tagger
+
+
+IMMUTA_API_PAGE_SIZE = 25_000
 
 
 @click.command(help="Tag existing data sources based on provided tagging info")
@@ -66,6 +71,7 @@ def main(
         client.get_data_source_list,
         search_text=search_text,
         search_schema=search_schema,
+        size=IMMUTA_API_PAGE_SIZE,
     ) as paginator:
         for data_source in paginator:
             data_sources_to_tag.append(
@@ -77,38 +83,144 @@ def main(
                 }
             )
 
-    progress_iterator = tqdm(data_sources_to_tag)
-    for data_source in progress_iterator:
-        progress_iterator.set_description(
-            desc=f"Tagging ID: {data_source['id']}, Name: {data_source['name']} :"
-        )
+    logging.info("Getting current data source and column tags")
+    current_data_source_tag_names_map: Dict[str, Set[str]] = defaultdict(set)
+    current_column_tag_names_map: Dict[str, Dict[str, Set[str]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+    for tag_info in client.get_all_data_source_and_column_tags()["hits"]:
+        data_source = tag_info["Data Source"]
+        tag_name = tag_info["Tag Name"]
+        column_name = tag_info["Column Name"]
+
+        if tag_name in IMMUTA_SPECIAL_TAGS:
+            continue
+
+        if tag_info["Type"] == "Data Source":
+            current_data_source_tag_names_map[data_source].add(tag_name)
+        elif tag_info["Type"] == "Column":
+            current_column_tag_names_map[data_source][column_name].add(tag_name)
+
+    logging.info("Determining changes in data source tags")
+    new_tag_name_to_data_source_ids: Dict[str, Set[int]] = defaultdict(set)
+    removed_tag_name_and_data_source_ids: Set[Tuple[int, str]] = set()
+    for data_source in data_sources_to_tag:
+        data_source_name = data_source["name"]
         data_source_tags = tagger.get_tags_for_data_source(
-            name=data_source["name"],
+            name=data_source_name,
             handler_type=data_source["handler_type"],
             connection_string=data_source["connection_string"],
         )
-        if data_source_tags:
-            logging.debug(f"\nAdding data source-level tags to {data_source['name']}.")
-            if not dry_run:
-                client.tag_data_source(id=data_source["id"], tag_data=data_source_tags)
-        dictionary = client.get_data_source_dictionary(id=data_source["id"])
+        data_source_tag_names = {tag_data["name"] for tag_data in data_source_tags}
+
+        current_data_source_tag_names = current_data_source_tag_names_map[
+            data_source_name
+        ]
+        new_data_source_tag_names = (
+            data_source_tag_names - current_data_source_tag_names
+        )
+
+        for tag_name in new_data_source_tag_names:
+            new_tag_name_to_data_source_ids[tag_name].add(data_source["id"])
+
+        removed_data_source_tag_names = (
+            current_data_source_tag_names - data_source_tag_names
+        )
+        for tag_name in removed_data_source_tag_names:
+            removed_tag_name_and_data_source_ids.add((data_source["id"], tag_name))
+
+    logging.info("Updating new data source tags")
+    progress_iterator = tqdm(
+        new_tag_name_to_data_source_ids.items(),
+        total=len(new_tag_name_to_data_source_ids),
+    )
+    for tag_name, data_source_ids in progress_iterator:
+        progress_iterator.set_description(
+            desc=f"[Tagging Data Sources] Tag: {tag_name}, # Data Sources: {len(data_source_ids)} :"
+        )
+        if not dry_run:
+            client.update_data_source_tags_in_bulk(
+                ids=list(data_source_ids),
+                tag_data=[
+                    {
+                        "name": tag_name,
+                        "source": "curated",
+                    }
+                ],
+            )
+    logging.info("Updating removed data source tags")
+    progress_iterator = tqdm(
+        new_tag_name_to_data_source_ids.items(),
+        total=len(new_tag_name_to_data_source_ids),
+    )
+    for data_source_id, tag_name in tqdm(removed_tag_name_and_data_source_ids):
+        progress_iterator.set_description(
+            desc=f"[Removing Data Source Tag] ID: {data_source_id}, Tag: {tag_name}"
+        )
+        if not dry_run:
+            client.delete_data_source_tag(data_source_id, tag_name)
+
+    logging.info("Determining data sources with new column tags")
+    data_sources_with_column_tags_to_update = set()
+    for column in tqdm(
+        tagger.tag_map_datadict.keys(),
+        total=len(tagger.tag_map_datadict),
+    ):
+        tag_names = tagger.get_tags_for_column(column)
+        with Paginator(
+            client.get_data_source_list,
+            search_text=search_text,
+            search_schema=search_schema,
+            columns=[column],
+            size=IMMUTA_API_PAGE_SIZE,
+        ) as paginator:
+            for data_source in paginator:
+                data_source_name = data_source["name"]
+                data_source_id = data_source["id"]
+                for tag_name in tag_names:
+                    if (
+                        tag_name
+                        not in current_column_tag_names_map[data_source_name][column]
+                    ):
+                        data_sources_with_column_tags_to_update.add(data_source_id)
+    for data_source in data_sources_to_tag:
+        data_source_name = data_source["name"]
+        data_source_id = data_source["id"]
+        wanted_column_tag_names = {
+            column: set(tagger.get_tags_for_column(column))
+            for column in current_column_tag_names_map[data_source_name].keys()
+        }
+        if current_column_tag_names_map[data_source_name] != wanted_column_tag_names:
+            data_sources_with_column_tags_to_update.add(data_source_id)
+
+    progress_iterator = tqdm(data_sources_to_tag)
+    for data_source in progress_iterator:
+        data_source_id = data_source["id"]
+        data_source_name = data_source["name"]
+        if data_source_id not in data_sources_with_column_tags_to_update:
+            continue
+        progress_iterator.set_description(
+            desc=f"[Tagging Columns] ID: {data_source_id}, Name: {data_source_name} :"
+        )
+
+        dictionary = client.get_data_source_dictionary(id=data_source_id)
         enriched_columns = tagger.enrich_columns_with_tagging(dictionary.metadata)
         if enriched_columns == dictionary.metadata:
-            logging.debug(
-                f"No change to column tags for data source: {data_source['name']}. Skipping."
+            logging.warning(
+                f"Expected a change to column tags for data source: {data_source_name}, but no change found. Skipping."
             )
             continue
         logging.debug(
-            f"Enriched columns for {data_source['name']}:"
+            f"Enriched columns for {data_source_name}:"
             f" {dictionary.dict()['metadata']}"
         )
         logging.info(
-            f"Change detected to column tags. Updating data source {data_source['name']}'s data dictionary."
+            f"Change detected to column tags. Updating data source {data_source_name}'s data dictionary."
         )
         dictionary.metadata = enriched_columns
         if not dry_run:
             client.update_data_source_dictionary(
-                id=data_source["id"], dictionary=dictionary
+                id=data_source_id, dictionary=dictionary
             )
     logging.info("FIN.")
 

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -143,9 +143,7 @@ def main(
         if not dry_run:
             client.update_data_source_tags_in_bulk(
                 ids=list(data_source_ids),
-                tag_data=[
-                    Tag(tag_name=tag_name).dict()
-                ],
+                tag_data=[Tag(tag_name=tag_name).dict()],
             )
     logging.info("Updating removed data source tags")
     progress_iterator = tqdm(removed_tag_name_and_data_source_ids)

--- a/fh_immuta_utils/scripts/tag_existing_data_sources.py
+++ b/fh_immuta_utils/scripts/tag_existing_data_sources.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 from fh_immuta_utils.client import get_client
 from fh_immuta_utils.config import parse_config
 from fh_immuta_utils.paginator import Paginator
-from fh_immuta_utils.tagging import IMMUTA_SPECIAL_TAGS, Tagger
+from fh_immuta_utils.tagging import IMMUTA_SPECIAL_TAGS, Tagger, Tag
 
 
 IMMUTA_API_PAGE_SIZE = 25_000
@@ -144,10 +144,7 @@ def main(
             client.update_data_source_tags_in_bulk(
                 ids=list(data_source_ids),
                 tag_data=[
-                    {
-                        "name": tag_name,
-                        "source": "curated",
-                    }
+                    Tag(tag_name=tag_name).dict()
                 ],
             )
     logging.info("Updating removed data source tags")

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -17,13 +17,6 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-# Tags created by Immuta by default
-IMMUTA_SPECIAL_TAGS = {
-    "New",
-    "Skip Stats Job",
-}
-
-
 class Tag(BaseModel):
     name: str
     source: str = "curated"

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -3,13 +3,11 @@ from collections import defaultdict
 import logging
 import os
 import glob
-from functools import partial
 from typing import Any, Dict, List, Iterator, Tuple, TYPE_CHECKING
 
 import yaml
 
 from pydantic import BaseModel
-from toolz.dicttoolz import keyfilter
 
 from .data_source import DataSourceColumn
 
@@ -17,6 +15,13 @@ if TYPE_CHECKING:
     from immuta_utils.client import ImmutaClient
 
 LOGGER = logging.getLogger(__name__)
+
+
+# Tags created by Immuta by default
+IMMUTA_SPECIAL_TAGS = {
+    "New",
+    "Skip Stats Job",
+}
 
 
 class Tag(BaseModel):


### PR DESCRIPTION
Optimize tagging process when only a small percentage of tags have changed.

Currently, the tagging script will make an Immuta API call at least once for each data source, and will make an API call to update a data dictionary (defining the column tags) regardless of whether or not the data dictionary has changed. When a data dictionary is updated via API call, regardless of whether or not the data dictionary has changed, Immuta will run Snowflake commands to update the data source's policies. Both of these processes take an excessively long time (>>4 hours) when the number of data sources is on the order of ~200K.

This PR optimizes the tagging script by updating data source tags and data dictionaries only when the set of tags has changed. When no tags have changed, the previous script takes ~6.5 minutes / 2.4K data sources, and the new script takes ~1.5 minutes / 2.4 K data sources. We expect an even larger difference as the number of data sources increase.

This PR also updates the tagging script so that it removes extra data source tags (it would only add new tags before).

Testing Strategy: Manual - test that the script appropriately adds and removes both data source and column tags.