### PR TITLE
Add option to skip stats job

### DIFF
--- a/fh_immuta_utils/data_source.py
+++ b/fh_immuta_utils/data_source.py
@@ -3,6 +3,8 @@ import logging
 
 from pydantic import BaseModel, Field
 
+from .tagging import SKIP_STATS_JOB_TAG
+
 LOGGER = logging.getLogger(__name__)
 
 HANDLER_TYPES = {
@@ -130,6 +132,8 @@ class DataSource(BaseModel):
     # or queryable (metadata is dynamically queried)
     type: str = "queryable"
     useDatesAsDirectory: bool = False
+    # Tags for the Data Source
+    tags: List[Dict[str, str]] = []
 
 
 class SchemaEvolutionMetadataConfigTemplate(BaseModel):
@@ -262,7 +266,10 @@ def make_bulk_create_objects(
         handlers.append(handler)
 
     ds = DataSource(
-        blobHandlerType=config["handler_type"], recordFormat="json", type="queryable"
+        blobHandlerType=config["handler_type"],
+        recordFormat="json",
+        type="queryable",
+        tags=[SKIP_STATS_JOB_TAG.dict()] if config.get("skip_stats_job", False) else [],
     )
     schema_evolution = make_schema_evolution_metadata(config)
 
@@ -316,6 +323,7 @@ def to_immuta_objects(
         # category="foo",
         description="bar",
         # owner="foo",
+        tags=[SKIP_STATS_JOB_TAG.dict()] if config.get("skip_stats_job", False) else [],
     )
     schema_evolution = make_schema_evolution_metadata(config)
 

--- a/fh_immuta_utils/tagging.py
+++ b/fh_immuta_utils/tagging.py
@@ -11,10 +11,10 @@ import yaml
 from pydantic import BaseModel
 from toolz.dicttoolz import keyfilter
 
-from .data_source import DataSourceColumn
 
 if TYPE_CHECKING:
-    from immuta_utils.client import ImmutaClient
+    from .client import ImmutaClient
+    from .data_source import DataSourceColumn
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +22,9 @@ LOGGER = logging.getLogger(__name__)
 class Tag(BaseModel):
     name: str
     source: str = "curated"
+
+
+SKIP_STATS_JOB_TAG = Tag(name="Skip Stats Job")
 
 
 class Tagger(object):
@@ -157,8 +160,8 @@ class Tagger(object):
             )
 
     def enrich_columns_with_tagging(
-        self, columns: List[DataSourceColumn]
-    ) -> List[DataSourceColumn]:
+        self, columns: List["DataSourceColumn"]
+    ) -> List["DataSourceColumn"]:
         """Append column tags to a pre-existing list of columns.
 
         Returns


### PR DESCRIPTION
The stats job is a per data source job that computes table statistics such as row counts. It is necessary for Immuta features such as k-anonymization, but not for subscription policies and column masking. Since this job requires reading table data, it can be extremely time consuming (I have measured ~6hrs / 2.3K tables, though I've been told this is slightly longer than typical).

This PR enables users to disable this stats job via an option in the dataset config file so that this expensive process can be disabled when it is not necessary. Mechanism: The stats job can be disabled by tagging the data source with the "Skip Stats Job" tag, which is a tag managed by Immuta itself.

Testing Strategy:

1. Unit tests
2. Manual - attempt to enroll a dataset with and without the skip stats job option enabled and verify the result in Immuta