### PR TITLE
Ensure data sources are enrolled before exiting manage data sources script

### DIFF
--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -9,6 +9,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import time
 from typing import Optional, List, Dict, Any, Union, Sequence, Iterator
 
 import requests
@@ -266,9 +267,7 @@ class ImmutaClient(LoggingMixin):
         handler: Union[Handler, Sequence[Handler]],
         schema_evolution: SchemaEvolutionMetadata,
         policy_handler=None,
-        handler_base_url=None,
-        dictionary=None,
-    ):
+    ) -> Optional[Dict[str, str]]:
         request_prefix = blob_handler_type(data_source.blobHandlerType)
         is_bulk_insert = isinstance(handler, list)
         if is_bulk_insert:
@@ -296,14 +295,28 @@ class ImmutaClient(LoggingMixin):
         self.log.debug("Response: %s", handler_response.text)
         # There's no ID given back for bulk create requests
         if handler_response.status_code == 200:
-            if not is_bulk_insert:
-                return self.get_data_source(handler_response.json()["dataSourceId"])
-            return None
+            return handler_response.json()
         if "already exists" in handler_response.text:
             self.log.info("Data source with name %s already exists", data_source.name)
             return None
         self.log.error("Error: %s", handler_response.text)
         handler_response.raise_for_status()
+
+    def wait_for_data_source_creation_completion(
+        self, connection_string: str, check_interval: int = 30
+    ) -> None:
+        """
+        Returns when the jobs for creating data sources with connection string `connection_string`
+        are complete. Checks the condition once every `check_interval` seconds.
+        """
+        while True:
+            try:
+                response = self.get(f"jobs?connectionString={connection_string}")
+                if int(response["pending"]) == 0:
+                    return
+            except HTTPError:
+                pass
+            time.sleep(check_interval)
 
     def update_data_source(
         self,

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -293,7 +293,6 @@ class ImmutaClient(LoggingMixin):
             f"{request_prefix}/handler", json=post_body
         )
         self.log.debug("Response: %s", handler_response.text)
-        # There's no ID given back for bulk create requests
         if handler_response.status_code == 200:
             return handler_response.json()
         if "already exists" in handler_response.text:
@@ -316,7 +315,9 @@ class ImmutaClient(LoggingMixin):
                 if n_pending_jobs == 0:
                     return
                 else:
-                    self.log.info(f"{n_pending_jobs} jobs remaining for {connection_string}")
+                    self.log.info(
+                        f"{n_pending_jobs} jobs remaining for {connection_string}"
+                    )
             except HTTPError:
                 pass
             time.sleep(check_interval)

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -309,17 +309,18 @@ class ImmutaClient(LoggingMixin):
         are complete. Checks the condition once every `check_interval` seconds.
         """
         while True:
-            try:
-                response = self.get(f"jobs?connectionString={connection_string}")
-                n_pending_jobs = int(response["pending"])
-                if n_pending_jobs == 0:
-                    return
-                else:
-                    self.log.info(
-                        f"{n_pending_jobs} jobs remaining for {connection_string}"
-                    )
-            except HTTPError:
-                pass
+            response = self.get(f"jobs?connectionString={connection_string}")
+            # empty response indicates that no jobs with the given connection string have run recently
+            if len(response) == 0:
+                return
+
+            n_pending_jobs = int(response["pending"])
+            if n_pending_jobs == 0:
+                return
+            else:
+                self.log.info(
+                    f"{n_pending_jobs} jobs remaining for {connection_string}"
+                )
             time.sleep(check_interval)
 
     def update_data_source(

--- a/fh_immuta_utils/client.py
+++ b/fh_immuta_utils/client.py
@@ -312,8 +312,11 @@ class ImmutaClient(LoggingMixin):
         while True:
             try:
                 response = self.get(f"jobs?connectionString={connection_string}")
-                if int(response["pending"]) == 0:
+                n_pending_jobs = int(response["pending"])
+                if n_pending_jobs == 0:
                     return
+                else:
+                    self.log.info(f"{n_pending_jobs} jobs remaining for {connection_string}")
             except HTTPError:
                 pass
             time.sleep(check_interval)

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -121,6 +121,7 @@ def main(config_file: str, glob_prefix: str, debug: bool, dry_run: bool) -> bool
                             schema_evolution=schema_evolution,
                         )
                         if response:
+                            # no connectionString in response if only one table in schema
                             if "connectionString" in response:
                                 connection_strings.add(response["connectionString"])
                         else:

--- a/fh_immuta_utils/scripts/manage_data_sources.py
+++ b/fh_immuta_utils/scripts/manage_data_sources.py
@@ -121,7 +121,8 @@ def main(config_file: str, glob_prefix: str, debug: bool, dry_run: bool) -> bool
                             schema_evolution=schema_evolution,
                         )
                         if response:
-                            connection_strings.add(response["connectionString"])
+                            if "connectionString" in response:
+                                connection_strings.add(response["connectionString"])
                         else:
                             failed_tables.add(data_source.name)
         if failed_tables:


### PR DESCRIPTION
The Immuta API v1 endpoint(s) for enrolling data sources is async i.e. not all data sources may be in the Immuta database by the time the Immuta API endpoint(s) return to the caller.

This PR modifies the script for enrolling data sources so that it does not exit until all data sources are fully enrolled i.e. is in the Immuta database. This is particularly important when running other processes that depend on a data source being in the Immuta database to function properly e.g. the tagging script.

Testing Strategy: Manual test - enroll a new dataset and check that all data sources are enrolled when the script exits.